### PR TITLE
contributing guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ We appreciate all commits and improvements, feel free to join Knot.x community a
 
 ## How to start
 Please refer to [Getting started](https://github.com/Cognifide/knotx#getting-started) section in the README file.
-After setting up Knot.x instance you may check if it works properly entering http://localhost:8092/content/local/simple.html (when running default configuration).
+After setting up Knot.x instance you may check if it works properly entering [http://localhost:8092/content/local/simple.html](http://localhost:8092/content/local/simple.html) (when running default configuration).
 
 ## Guidelines
 Below is short list of things that will help us keep Knot.x quality and accept pull requests:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,10 +8,29 @@ We appreciate all commits and improvements, feel free to join Knot.x community a
 Please refer to [Getting started](https://github.com/Cognifide/knotx#getting-started) section in the README file.
 After setting up Knot.x instance you may check if it works properly entering [http://localhost:8092/content/local/simple.html](http://localhost:8092/content/local/simple.html) (when running default configuration).
 
-## Guidelines
+## Knot.x Contributor License Agreement
+Project License: [Apache License Version 2.0](https://github.com/Cognifide/knotx/blob/master/LICENSE)
+- You will only Submit Contributions where You have authored 100% of the content.
+- You will only Submit Contributions to which You have the necessary rights. This means that if You are employed You have received the necessary permissions from Your employer to make the Contributions.
+- Whatever content You Contribute will be provided under the Project License(s).
+
+## Commit Messages
+When writing a commit message, please follow [How to Write a Git Commit Message](http://chris.beams.io/posts/git-commit/) guideline.
+
+## Pull Requests
+Please add the following lines to your pull request description:
+
+```
+---
+
+I hereby agree to the terms of the Knot.x Contributor License Agreement.
+```
+
+## Coding Conventions
 Below is short list of things that will help us keep Knot.x quality and accept pull requests:
-- follow [google styleguide](https://github.com/HPI-Information-Systems/Metanome/wiki/Installing-the-google-styleguide-settings-in-intellij-and-eclipse),
+- Follow [google styleguide](https://github.com/google/styleguide) code formatting,
 - write tests,
-- write a [good commit message](http://chris.beams.io/posts/git-commit/),
+- write javadoc, especially for interfaces and abstract methods,
 - update documentation,
-- when committing an improvement, try to show it in local demo example.
+- when committing an improvement, try to show it in local demo example,
+- when logging use proper levels: `INFO` and `WARNING` should log only very important messages. 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,7 +15,7 @@ Project License: [Apache License Version 2.0](https://github.com/Cognifide/knotx
 - Whatever content You Contribute will be provided under the Project License(s).
 
 ## Commit Messages
-When writing a commit message, please follow [How to Write a Git Commit Message](http://chris.beams.io/posts/git-commit/) guideline.
+When writing a commit message, please follow the guidelines in [How to Write a Git Commit Message](http://chris.beams.io/posts/git-commit/).
 
 ## Pull Requests
 Please add the following lines to your pull request description:
@@ -28,9 +28,9 @@ I hereby agree to the terms of the Knot.x Contributor License Agreement.
 
 ## Coding Conventions
 Below is short list of things that will help us keep Knot.x quality and accept pull requests:
-- Follow [google styleguide](https://github.com/google/styleguide) code formatting,
+- Follow [Google Style Guide](https://github.com/google/styleguide) code formatting,
 - write tests,
 - write javadoc, especially for interfaces and abstract methods,
-- update documentation,
+- update [documentation](https://github.com/Cognifide/knotx/blob/master/README.md),
 - when committing an improvement, try to show it in local demo example,
 - when logging use proper levels: `INFO` and `WARNING` should log only very important messages. 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,6 +12,6 @@ After setting up Knot.x instance you may check if it works properly entering htt
 Below is short list of things that will help us keep Knot.x quality and accept pull requests:
 - follow [google styleguide](https://github.com/HPI-Information-Systems/Metanome/wiki/Installing-the-google-styleguide-settings-in-intellij-and-eclipse),
 - write tests,
-- write a [good commit message][commit],
+- write a [good commit message](http://chris.beams.io/posts/git-commit/),
 - update documentation,
 - when committing an improvement, try to show it in local demo example.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,17 @@
+![Cognifide logo](http://cognifide.github.io/images/cognifide-logo.png)
+
+# How to contribute to Knot.x
+Thank you for taking the time to contribute!
+We appreciate all commits and improvements, feel free to join Knot.x community and contribute.
+
+## How to start
+Please refer to [Getting started](https://github.com/Cognifide/knotx#getting-started) section in the README file.
+After setting up Knot.x instance you may check if it works properly entering http://localhost:8092/content/local/simple.html (when running default configuration).
+
+## Guidelines
+Below is short list of things that will help us keep Knot.x quality and accept pull requests:
+- follow [google styleguide](https://github.com/HPI-Information-Systems/Metanome/wiki/Installing-the-google-styleguide-settings-in-intellij-and-eclipse),
+- write tests,
+- write a [good commit message][commit],
+- update documentation,
+- when committing an improvement, try to show it in local demo example.


### PR DESCRIPTION
File that explains contributing guidelines in Knot.x in GitHub convention: https://github.com/blog/1184-contributing-guidelines