### PR TITLE
pom reordering

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,6 +21,12 @@
          xmlns="http://maven.apache.org/POM/4.0.0"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-parent</artifactId>
+        <version>1.3.5.RELEASE</version>
+    </parent>
+
     <groupId>com.cognifide.knotx</groupId>
     <artifactId>knotx-root</artifactId>
     <version>1.0.0-SNAPSHOT</version>
@@ -37,12 +43,6 @@
         </license>
     </licenses>
 
-    <parent>
-        <groupId>org.springframework.boot</groupId>
-        <artifactId>spring-boot-starter-parent</artifactId>
-        <version>1.3.5.RELEASE</version>
-    </parent>
-
     <developers>
         <developer>
             <name>Tomasz Michalak</name>
@@ -54,24 +54,29 @@
         </developer>
     </developers>
 
+    <modules>
+        <module>knotx-core</module>
+        <module>knotx-example</module>
+    </modules>
+
     <scm>
         <connection>scm:git:https://github.com/Cognifide/knotx.git</connection>
-        <url>scm:git:https://github.com/Cognifide/knotx.git</url>
         <developerConnection>scm:git|https://github.com/Cognifide/knotx.git</developerConnection>
         <tag>HEAD</tag>
+        <url>https://github.com/Cognifide/knotx</url>
     </scm>
 
     <distributionManagement>
-        <snapshotRepository>
-            <id>sonatype-nexus-snapshots</id>
-            <name>Sonatype Nexus Snapshots</name>
-            <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
-        </snapshotRepository>
         <repository>
             <id>sonatype-nexus-staging</id>
             <name>Nexus Release Repository</name>
             <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
         </repository>
+        <snapshotRepository>
+            <id>sonatype-nexus-snapshots</id>
+            <name>Sonatype Nexus Snapshots</name>
+            <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
+        </snapshotRepository>
     </distributionManagement>
 
     <properties>
@@ -219,10 +224,4 @@
             </plugin>
         </plugins>
     </build>
-
-    <modules>
-        <module>knotx-core</module>
-        <module>knotx-example</module>
-    </modules>
-
 </project>


### PR DESCRIPTION
I took me some time to realize that knotx is child of `spring-boot-starter-parent` (after i was wondering why we have some strange-looking configuration skipped within `core` profile)