### PR TITLE
Filesystem Repository should NOT create new files

### DIFF
--- a/knotx-core/knotx-repository/knotx-repository-filesystem/src/main/java/com/cognifide/knotx/repository/FilesystemRepositoryVerticle.java
+++ b/knotx-core/knotx-repository/knotx-repository-filesystem/src/main/java/com/cognifide/knotx/repository/FilesystemRepositoryVerticle.java
@@ -46,9 +46,8 @@ import rx.Observable;
 public class FilesystemRepositoryVerticle extends AbstractVerticle {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(FilesystemRepositoryVerticle.class);
-
+  private static final OpenOptions OPEN_OPTIONS = new OpenOptions().setCreate(false).setWrite(false);
   private String catalogue;
-
   private String address;
 
   @Override
@@ -84,7 +83,7 @@ public class FilesystemRepositoryVerticle extends AbstractVerticle {
 
     LOGGER.trace("Fetching file `{}` from local repository.", localFilePath);
 
-    return fileSystem.openObservable(localFilePath, new OpenOptions().setCreate(false))
+    return fileSystem.openObservable(localFilePath, OPEN_OPTIONS)
         .flatMap(this::processFile)
         .map(buffer -> new HttpResponseWrapper().setStatusCode(HttpResponseStatus.OK).setHeaders(headers(contentType)).setBody(buffer))
         .defaultIfEmpty(new HttpResponseWrapper().setStatusCode(HttpResponseStatus.NOT_FOUND))

--- a/knotx-core/knotx-repository/knotx-repository-filesystem/src/main/java/com/cognifide/knotx/repository/FilesystemRepositoryVerticle.java
+++ b/knotx-core/knotx-repository/knotx-repository-filesystem/src/main/java/com/cognifide/knotx/repository/FilesystemRepositoryVerticle.java
@@ -84,7 +84,7 @@ public class FilesystemRepositoryVerticle extends AbstractVerticle {
 
     LOGGER.trace("Fetching file `{}` from local repository.", localFilePath);
 
-    return fileSystem.openObservable(localFilePath, new OpenOptions())
+    return fileSystem.openObservable(localFilePath, new OpenOptions().setCreate(false))
         .flatMap(this::processFile)
         .map(buffer -> new HttpResponseWrapper().setStatusCode(HttpResponseStatus.OK).setHeaders(headers(contentType)).setBody(buffer))
         .defaultIfEmpty(new HttpResponseWrapper().setStatusCode(HttpResponseStatus.NOT_FOUND))


### PR DESCRIPTION
JAVADOC for `openObservable` says:

> The file is opened for both reading and writing. If the file does not already exist it will be created.

this needed to be fixed.