### PR TITLE
Make configuration consistent

### DIFF
--- a/documentation/src/main/wiki/GettingStarted.md
+++ b/documentation/src/main/wiki/GettingStarted.md
@@ -127,16 +127,14 @@ The configuration consists of **verticles** object containing set of configurati
   "com.cognifide.knotx.repository.HttpRepositoryVerticle": {
     "config": {
       "address": "knotx.core.repository.http",
-      "configuration": {
-        "client.options": {
-          "maxPoolSize": 1000,
-          "keepAlive": false,
-          "tryUseCompression": true
-        },
-        "client.destination" : {
-          "domain": "localhost",
-          "port": 3001
-        }
+      "client.options": {
+        "maxPoolSize": 1000,
+        "keepAlive": false,
+        "tryUseCompression": true
+      },
+      "client.destination" : {
+        "domain": "localhost",
+        "port": 3001
       }
     }
   },
@@ -147,9 +145,8 @@ This section configures the Knot.x HTTP Repository Verticle that fetches a templ
 The config node consists of:
 
 - **address** - the event bus address on which Http Repository Verticle listens for template requests.
-- **configuration** - it's a configuration section specific to the Http protocol used by verticle, it contains:
--- **client.options** - HTTP Client options used when communicating with the destination repository. See [HttpClientOptions](http://vertx.io/docs/apidocs/io/vertx/core/http/HttpClientOptions.html) to get all options supported.
--- **client.destination** - Allows to specify **domain** and **port** of the HTTP repository endpoint.
+- **client.options** - HTTP Client options used when communicating with the destination repository. See [HttpClientOptions](http://vertx.io/docs/apidocs/io/vertx/core/http/HttpClientOptions.html) to get all options supported.
+- **client.destination** - Allows to specify **domain** and **port** of the HTTP repository endpoint.
 
 #### 1.2. Filesystem Repository section
 ```json
@@ -157,9 +154,7 @@ The config node consists of:
   "com.cognifide.knotx.repository.FilesystemRepositoryVerticle": {
     "config": {
       "address": "knotx.core.repository.filesystem",
-      "configuration": {
-        "catalogue": ""
-      }
+      "catalogue": ""
     }
   },
   ...
@@ -169,8 +164,7 @@ If you need to take files from a local machine, this is the kind of repository y
 The config node consists of:
 
 - **address** - the event bus address on which file system Repository Verticle listens for template requests.
-- **configuration** - it's a configuration section specific to the file system.
--- **catalogue** - it determines where to take the resources from. If it's left empty, they will be taken from the classpath. It may be treated like a prefix to the requested resources.
+- **catalogue** - it determines where to take the resources from. If it's left empty, they will be taken from the classpath. It may be treated like a prefix to the requested resources.
 
 #### 1.3. Engine section
 ```json

--- a/documentation/src/main/wiki/ProductionUsage.md
+++ b/documentation/src/main/wiki/ProductionUsage.md
@@ -46,25 +46,21 @@ The *core* module contains four Knot.x verticles without any sample data. Here's
     "com.cognifide.knotx.repository.HttpRepositoryVerticle": {
       "config": {
         "address": "knotx.core.repository.http",
-        "configuration": {
-          "client.options": {
-            "maxPoolSize": 1000,
-            "keepAlive": false,
-            "tryUseCompression": true
-          },
-          "client.destination": {
-            "domain": "localhost",
-            "port": 3001
-          }
+        "client.options": {
+          "maxPoolSize": 1000,
+          "keepAlive": false,
+          "tryUseCompression": true
+        },
+        "client.destination": {
+          "domain": "localhost",
+          "port": 3001
         }
       }
     },
     "com.cognifide.knotx.repository.FilesystemRepositoryVerticle": {
       "config": {
         "address": "knotx.core.repository.filesystem",
-        "configuration": {
-          "catalogue": ""
-        }
+        "catalogue": ""
       }
     },
     "com.cognifide.knotx.engine.TemplateEngineVerticle": {
@@ -174,7 +170,8 @@ Knot.x server requires JSON configuration with *config* object. **Config** secti
         "address": "knotx.core.engine"
       }
      }
-     ...
+    }
+}
  ```
 ####Verticle configuration
 Each verticle requires JSON configuration of **config** object. The configuration consists of the same parameters as previous examples.
@@ -182,16 +179,14 @@ For instance, a configuration JSON for the *HTTP repository* verticle could look
 ```json
 {
   "address": "knotx.core.repository.http",
-  "configuration": {
-    "client.options": {
-      "maxPoolSize": 1000,
-      "keepAlive": false,
-      "tryUseCompression": true
-    },
-    "client.destination" : {
-      "domain": "localhost",
-      "port": 3001
-    }
+  "client.options": {
+    "maxPoolSize": 1000,
+    "keepAlive": false,
+    "tryUseCompression": true
+  },
+  "client.destination" : {
+    "domain": "localhost",
+    "port": 3001
   }
 }
 ```

--- a/knotx-core/knotx-repository/knotx-repository-filesystem/src/main/java/com/cognifide/knotx/repository/FilesystemRepositoryVerticle.java
+++ b/knotx-core/knotx-repository/knotx-repository-filesystem/src/main/java/com/cognifide/knotx/repository/FilesystemRepositoryVerticle.java
@@ -54,7 +54,7 @@ public class FilesystemRepositoryVerticle extends AbstractVerticle {
   public void init(Vertx vertx, Context context) {
     super.init(vertx, context);
     this.address = config().getString("address");
-    this.catalogue = config().getJsonObject("configuration").getString("catalogue");
+    this.catalogue = config().getString("catalogue");
   }
 
   @Override

--- a/knotx-core/knotx-repository/knotx-repository-filesystem/src/main/resources/knotx-repository-filesystem.json
+++ b/knotx-core/knotx-repository/knotx-repository-filesystem/src/main/resources/knotx-repository-filesystem.json
@@ -1,6 +1,4 @@
 {
   "address": "knotx.core.repository.filesystem",
-  "configuration": {
-    "catalogue": ""
-  }
+  "catalogue": ""
 }

--- a/knotx-core/knotx-repository/knotx-repository-http/src/main/java/com/cognifide/knotx/repository/HttpRepositoryVerticle.java
+++ b/knotx-core/knotx-repository/knotx-repository-http/src/main/java/com/cognifide/knotx/repository/HttpRepositoryVerticle.java
@@ -53,11 +53,9 @@ public class HttpRepositoryVerticle extends AbstractVerticle {
   @Override
   public void init(Vertx vertx, Context context) {
     super.init(vertx, context);
-    this.address = config().getString("address");
-
-    JsonObject configuration = config().getJsonObject("configuration");
-    clientOptions = configuration.getJsonObject("client.options", new JsonObject());
-    clientDestination = configuration.getJsonObject("client.destination");
+    address = config().getString("address");
+    clientOptions = config().getJsonObject("client.options", new JsonObject());
+    clientDestination = config().getJsonObject("client.destination");
   }
 
   @Override

--- a/knotx-core/knotx-repository/knotx-repository-http/src/main/resources/knotx-repository-http.json
+++ b/knotx-core/knotx-repository/knotx-repository-http/src/main/resources/knotx-repository-http.json
@@ -1,14 +1,12 @@
 {
   "address": "knotx.core.repository.http",
-  "configuration": {
-    "client.options": {
-      "maxPoolSize": 1000,
-      "keepAlive": false,
-      "tryUseCompression": true
-    },
-    "client.destination": {
-      "domain": "localhost",
-      "port": 3001
-    }
+  "client.options": {
+    "maxPoolSize": 1000,
+    "keepAlive": false,
+    "tryUseCompression": true
+  },
+  "client.destination": {
+    "domain": "localhost",
+    "port": 3001
   }
 }

--- a/knotx-core/knotx-standalone/src/main/resources/knotx-standalone.json
+++ b/knotx-core/knotx-standalone/src/main/resources/knotx-standalone.json
@@ -61,25 +61,21 @@
     "com.cognifide.knotx.repository.HttpRepositoryVerticle": {
       "config": {
         "address": "knotx.core.repository.http",
-        "configuration": {
-          "client.options": {
-            "maxPoolSize": 1000,
-            "keepAlive": false,
-            "tryUseCompression": true
-          },
-          "client.destination": {
-            "domain": "localhost",
-            "port": 3001
-          }
+        "client.options": {
+          "maxPoolSize": 1000,
+          "keepAlive": false,
+          "tryUseCompression": true
+        },
+        "client.destination": {
+          "domain": "localhost",
+          "port": 3001
         }
       }
     },
     "com.cognifide.knotx.repository.FilesystemRepositoryVerticle": {
       "config": {
         "address": "knotx.core.repository.filesystem",
-        "configuration": {
-          "catalogue": ""
-        }
+        "catalogue": ""
       }
     },
     "com.cognifide.knotx.engine.TemplateEngineVerticle": {

--- a/knotx-example/knotx-example-monolith/src/main/resources/knotx-example-monolith.json
+++ b/knotx-example/knotx-example-monolith/src/main/resources/knotx-example-monolith.json
@@ -61,25 +61,21 @@
     "com.cognifide.knotx.repository.HttpRepositoryVerticle": {
       "config": {
         "address": "knotx.core.repository.http",
-        "configuration": {
-          "client.options": {
-            "maxPoolSize": 1000,
-            "keepAlive": false,
-            "tryUseCompression": true
-          },
-          "client.destination": {
-            "domain": "localhost",
-            "port": 3001
-          }
+        "client.options": {
+          "maxPoolSize": 1000,
+          "keepAlive": false,
+          "tryUseCompression": true
+        },
+        "client.destination": {
+          "domain": "localhost",
+          "port": 3001
         }
       }
     },
     "com.cognifide.knotx.repository.FilesystemRepositoryVerticle": {
       "config": {
         "address": "knotx.core.repository.filesystem",
-        "configuration": {
-          "catalogue": ""
-        }
+        "catalogue": ""
       }
     },
     "com.cognifide.knotx.engine.TemplateEngineVerticle": {


### PR DESCRIPTION
Removed `configuration` level from json configs.
---

I hereby agree to the terms of the Knot.x Contributor License Agreement.