### PR TITLE
Enable customization of Http Client Facade

### DIFF
--- a/knotx-adapters/knotx-adapter-action-http/src/test/java/com/cognifide/knotx/adapter/service/http/HttpClientFacadeTest.java
+++ b/knotx-adapters/knotx-adapter-action-http/src/test/java/com/cognifide/knotx/adapter/service/http/HttpClientFacadeTest.java
@@ -19,6 +19,7 @@ package com.cognifide.knotx.adapter.service.http;
 
 import com.google.common.collect.Lists;
 
+import com.cognifide.knotx.adapter.common.exception.UnsupportedServiceException;
 import com.cognifide.knotx.adapter.common.http.HttpClientFacade;
 import com.cognifide.knotx.adapter.common.http.ServiceMetadata;
 import com.cognifide.knotx.dataobjects.ClientRequest;
@@ -168,7 +169,7 @@ public class HttpClientFacadeTest {
         response -> context.fail("Error should occur!"),
         error -> {
           {
-            context.assertEquals("No matching service definition for the requested path '/not/supported/path'", error.getMessage());
+            context.assertEquals(UnsupportedServiceException.class, error.getClass());
             Mockito.verify(mockedHttpClient, Mockito.times(0)).request(Matchers.any(), Matchers.anyInt(), Matchers.anyString(), Matchers.anyString());
             async.complete();
           }

--- a/knotx-adapters/knotx-adapter-action-http/src/test/java/com/cognifide/knotx/adapter/service/http/HttpClientFacadeTest.java
+++ b/knotx-adapters/knotx-adapter-action-http/src/test/java/com/cognifide/knotx/adapter/service/http/HttpClientFacadeTest.java
@@ -168,7 +168,7 @@ public class HttpClientFacadeTest {
         response -> context.fail("Error should occur!"),
         error -> {
           {
-            context.assertEquals("Parameter `params.path`: `/not/supported/path` not supported!", error.getMessage());
+            context.assertEquals("No matching service definition for the requested path '/not/supported/path'", error.getMessage());
             Mockito.verify(mockedHttpClient, Mockito.times(0)).request(Matchers.any(), Matchers.anyInt(), Matchers.anyString(), Matchers.anyString());
             async.complete();
           }

--- a/knotx-adapters/knotx-adapter-common/src/main/java/com/cognifide/knotx/adapter/common/http/HttpClientFacade.java
+++ b/knotx-adapters/knotx-adapter-common/src/main/java/com/cognifide/knotx/adapter/common/http/HttpClientFacade.java
@@ -110,7 +110,7 @@ public class HttpClientFacade {
     if (serviceMetadata.isPresent()) {
       serviceData = Pair.of(serviceRequest, serviceMetadata.get());
     } else {
-      final String error = String.format("Parameter `params.path`: `%s` not supported!", serviceRequest.path());
+      final String error = String.format("No matching service definition for the requested path '%s'", serviceRequest.path());
       throw new UnsupportedServiceException(error);
     }
     return serviceData;

--- a/knotx-adapters/knotx-adapter-common/src/main/java/com/cognifide/knotx/adapter/common/http/HttpClientFacade.java
+++ b/knotx-adapters/knotx-adapter-common/src/main/java/com/cognifide/knotx/adapter/common/http/HttpClientFacade.java
@@ -62,56 +62,78 @@ public class HttpClientFacade {
   public Observable<ClientResponse> process(JsonObject message, HttpMethod method) {
     return Observable.just(message)
         .doOnNext(this::validateContract)
-        .map(this::prepareRequest)
+        .map(this::prepareRequestData)
         .flatMap(serviceRequest -> callService(serviceRequest, method))
         .flatMap(this::wrapResponse)
         .defaultIfEmpty(INTERNAL_SERVER_ERROR_RESPONSE);
   }
 
-  private void validateContract(JsonObject message) {
+  /**
+   * Method to validate contract or params JsonObject for the Adapter Service<br/>
+   * The contract checks if all required fields exists in the object. throwing AdapterServiceContractException
+   * in case of contract violation.<br/>
+   * @param message - Event Bus Json Object message that contains 'clientRequest' and 'params' objects.
+   */
+  protected void validateContract(JsonObject message) {
     final boolean pathPresent = message.getJsonObject(PARAMS_KEY).containsKey(PATH_PROPERTY_KEY);
     if (!pathPresent) {
       throw new AdapterServiceContractException("Parameter `path` was not defined in `params`!");
     }
   }
 
-  private Pair<ClientRequest, ServiceMetadata> prepareRequest(JsonObject message) {
-    final Pair<ClientRequest, ServiceMetadata> serviceRequest;
-
-    final ClientRequest originalRequest = new ClientRequest(message.getJsonObject(REQUEST_KEY));
-    final JsonObject params = message.getJsonObject(PARAMS_KEY);
-
-    final String servicePath = UriTransformer.resolveServicePath(params.getString(PATH_PROPERTY_KEY), originalRequest);
-
-    final Optional<ServiceMetadata> serviceMetadata = findServiceMetadata(servicePath);
-    if (serviceMetadata.isPresent()) {
-      final ClientRequest serviceRequestWrapper = new ClientRequest(originalRequest.toJson());
-      serviceRequestWrapper.setPath(servicePath);
-      serviceRequest = Pair.of(serviceRequestWrapper, serviceMetadata.get());
-    } else {
-      final String error = String.format("Parameter `params.path`: `%s` not supported!", servicePath);
-      throw new UnsupportedServiceException(error);
-    }
+  /**
+   * Method responsible for building request to the service.</br>
+   * <br/>
+   * The responsibility of the method is to build ClientRequest based on the original Http Request<br/>
+   *   - It must set path property of the request based on the params<br/>
+   *   - It might set headers of the request if needed.</br>
+   * <br/>
+   * In case of headers created modified in this method, ensure that your service configuration
+   * allows passing those headers to the target service. See 'allowed.request.headers' section of the configuration
+   * </br>
+   * @param originalRequest - ClientRequest representing original request comming to the Knot.x
+   * @param params - JsonObject of the params to be used to build request.
+   * @return ClientRequest representing Http request to the target service
+   */
+  protected ClientRequest buildServiceRequest(ClientRequest originalRequest, JsonObject params) {
+    final ClientRequest serviceRequest = new ClientRequest(originalRequest.toJson())
+        .setPath(UriTransformer.resolveServicePath(params.getString(PATH_PROPERTY_KEY), originalRequest));
 
     return serviceRequest;
+  }
+
+  private Pair<ClientRequest, ServiceMetadata> prepareRequestData(JsonObject message) {
+    final Pair<ClientRequest, ServiceMetadata> serviceData;
+
+    final ClientRequest originalRequest = new ClientRequest(message.getJsonObject(REQUEST_KEY));
+    final ClientRequest serviceRequest = buildServiceRequest(originalRequest, message.getJsonObject(PARAMS_KEY));
+
+    final Optional<ServiceMetadata> serviceMetadata = findServiceMetadata(serviceRequest.path());
+    if (serviceMetadata.isPresent()) {
+      serviceData = Pair.of(serviceRequest, serviceMetadata.get());
+    } else {
+      final String error = String.format("Parameter `params.path`: `%s` not supported!", serviceRequest.path());
+      throw new UnsupportedServiceException(error);
+    }
+    return serviceData;
   }
 
   private Optional<ServiceMetadata> findServiceMetadata(String servicePath) {
     return services.stream().filter(metadata -> servicePath.matches(metadata.getPath())).findAny();
   }
 
-  private Observable<HttpClientResponse> callService(Pair<ClientRequest, ServiceMetadata> serviceRequest, HttpMethod method) {
-    final ClientRequest requestWrapper = serviceRequest.getLeft();
-    final ServiceMetadata serviceMetadata = serviceRequest.getRight();
+  private Observable<HttpClientResponse> callService(Pair<ClientRequest, ServiceMetadata> serviceData, HttpMethod method) {
+    final ClientRequest serviceRequest = serviceData.getLeft();
+    final ServiceMetadata serviceMetadata = serviceData.getRight();
 
     return Observable.create(subscriber -> {
-      HttpClientRequest request = httpClient.request(method, serviceMetadata.getPort(), serviceMetadata.getDomain(), requestWrapper.path());
-      Observable<HttpClientResponse> resp = request.toObservable();
+      HttpClientRequest httpRequest = httpClient.request(method, serviceMetadata.getPort(), serviceMetadata.getDomain(), serviceRequest.path());
+      Observable<HttpClientResponse> resp = httpRequest.toObservable();
       resp.subscribe(subscriber);
-      request.headers().addAll(getFilteredHeaders(requestWrapper.headers(), serviceMetadata.getAllowedRequestHeaderPatterns()));
-      request.headers().remove(HttpHeaders.CONTENT_LENGTH.toString());
+      httpRequest.headers().addAll(getFilteredHeaders(serviceRequest.headers(), serviceMetadata.getAllowedRequestHeaderPatterns()));
+      httpRequest.headers().remove(HttpHeaders.CONTENT_LENGTH.toString());
 
-      request.end();
+      httpRequest.end();
     });
   }
 

--- a/knotx-adapters/knotx-adapter-common/src/main/java/com/cognifide/knotx/adapter/common/http/HttpClientFacade.java
+++ b/knotx-adapters/knotx-adapter-common/src/main/java/com/cognifide/knotx/adapter/common/http/HttpClientFacade.java
@@ -96,10 +96,8 @@ public class HttpClientFacade {
    * @return ClientRequest representing Http request to the target service
    */
   protected ClientRequest buildServiceRequest(ClientRequest originalRequest, JsonObject params) {
-    final ClientRequest serviceRequest = new ClientRequest(originalRequest.toJson())
+    return new ClientRequest(originalRequest.toJson())
         .setPath(UriTransformer.resolveServicePath(params.getString(PATH_PROPERTY_KEY), originalRequest));
-
-    return serviceRequest;
   }
 
   private Pair<ClientRequest, ServiceMetadata> prepareRequestData(JsonObject message) {

--- a/knotx-adapters/knotx-adapter-service-http/src/test/java/com/cognifide/knotx/adapter/service/http/HttpClientFacadeTest.java
+++ b/knotx-adapters/knotx-adapter-service-http/src/test/java/com/cognifide/knotx/adapter/service/http/HttpClientFacadeTest.java
@@ -168,7 +168,7 @@ public class HttpClientFacadeTest {
         response -> context.fail("Error should occur!"),
         error -> {
           {
-            context.assertEquals("Parameter `params.path`: `/not/supported/path` not supported!", error.getMessage());
+            context.assertEquals("No matching service definition for the requested path '/not/supported/path'", error.getMessage());
             Mockito.verify(mockedHttpClient, Mockito.times(0)).request(Matchers.any(), Matchers.anyInt(), Matchers.anyString(), Matchers.anyString());
             async.complete();
           }

--- a/knotx-adapters/knotx-adapter-service-http/src/test/java/com/cognifide/knotx/adapter/service/http/HttpClientFacadeTest.java
+++ b/knotx-adapters/knotx-adapter-service-http/src/test/java/com/cognifide/knotx/adapter/service/http/HttpClientFacadeTest.java
@@ -19,6 +19,7 @@ package com.cognifide.knotx.adapter.service.http;
 
 import com.google.common.collect.Lists;
 
+import com.cognifide.knotx.adapter.common.exception.UnsupportedServiceException;
 import com.cognifide.knotx.adapter.common.http.HttpClientFacade;
 import com.cognifide.knotx.adapter.common.http.ServiceMetadata;
 import com.cognifide.knotx.dataobjects.ClientResponse;
@@ -168,7 +169,7 @@ public class HttpClientFacadeTest {
         response -> context.fail("Error should occur!"),
         error -> {
           {
-            context.assertEquals("No matching service definition for the requested path '/not/supported/path'", error.getMessage());
+            context.assertEquals(UnsupportedServiceException.class, error.getClass());
             Mockito.verify(mockedHttpClient, Mockito.times(0)).request(Matchers.any(), Matchers.anyInt(), Matchers.anyString(), Matchers.anyString());
             async.complete();
           }


### PR DESCRIPTION
Enable customization of Http Client Facade
And custom implementation can:
- Create it's own http facade extending core facade
- Custom implemention need overwrite validateContract method to validate params object
- Custom implemention need overwrite buildServiceRequest method to create http request suitable for the custom implementation based on params.