### PR TITLE
Bugfix/placeholders are not encoded

### DIFF
--- a/documentation/src/main/wiki/SnippetProcessing.md
+++ b/documentation/src/main/wiki/SnippetProcessing.md
@@ -62,6 +62,11 @@ Available placeholders are:
 * `{slingUri.extension}` - is the original requests sling extension. From `/a/b/c.sel.it.html/suffix.xml?query` it will produce `html`
 * `{slingUri.suffix}` - is the original requests sling suffix. From `/a/b/c.sel.it.html/suffix.html?query` it will produce `/suffix.html`
 
+All placeholders are always substituted with encoded values according to the RFC standard. However, there are two exceptions:
+
+- Space character is substituted by **%20** instead of **+**
+- Slash character **/** remains as it is
+
 How would you use a placeholder within your script:
 ```html
 <script data-api-type="templating" type="text/x-handlebars-template"

--- a/knotx-adapters/knotx-adapter-common/src/main/java/com/cognifide/knotx/adapter/common/placeholders/UriTransformer.java
+++ b/knotx-adapters/knotx-adapter-common/src/main/java/com/cognifide/knotx/adapter/common/placeholders/UriTransformer.java
@@ -28,7 +28,12 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import io.vertx.core.logging.Logger;
+import io.vertx.core.logging.LoggerFactory;
+
 public final class UriTransformer {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(UriTransformer.class);
 
   private static List<PlaceholderSubstitutor> placeholderSubstitutors =
       Arrays.asList(new RequestPlaceholderSubstitutor(), new UriPlaceholderSubstitutor());
@@ -67,7 +72,8 @@ public final class UriTransformer {
   private static String encodeValue(String value) {
     try {
       return URLEncoder.encode(value, "UTF-8").replace("+", "%20").replace("%2F", "/");
-    } catch (UnsupportedEncodingException var3) {
+    } catch (UnsupportedEncodingException ex) {
+      LOGGER.fatal("Unexpected Exception - Unsupported encoding UTF-8", ex);
       throw new UnsupportedCharsetException("UTF-8");
     }
   }

--- a/knotx-adapters/knotx-adapter-common/src/main/java/com/cognifide/knotx/adapter/common/placeholders/UriTransformer.java
+++ b/knotx-adapters/knotx-adapter-common/src/main/java/com/cognifide/knotx/adapter/common/placeholders/UriTransformer.java
@@ -21,6 +21,9 @@ import com.cognifide.knotx.dataobjects.ClientRequest;
 
 import org.apache.commons.lang3.StringUtils;
 
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
+import java.nio.charset.UnsupportedCharsetException;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -40,7 +43,7 @@ public final class UriTransformer {
 
     for (String placeholder : placeholders) {
       serviceUri = serviceUri.replace("{" + placeholder + "}",
-          getPlaceholderValue(request, placeholder));
+          encodeValue(getPlaceholderValue(request, placeholder)));
     }
 
     return serviceUri;
@@ -59,5 +62,13 @@ public final class UriTransformer {
         .filter(str -> str != null)
         .findFirst()
         .orElse("");
+  }
+
+  private static String encodeValue(String value) {
+    try {
+      return URLEncoder.encode(value, "UTF-8").replace("+", "%20");
+    } catch (UnsupportedEncodingException var3) {
+      throw new UnsupportedCharsetException("UTF-8");
+    }
   }
 }

--- a/knotx-adapters/knotx-adapter-common/src/main/java/com/cognifide/knotx/adapter/common/placeholders/UriTransformer.java
+++ b/knotx-adapters/knotx-adapter-common/src/main/java/com/cognifide/knotx/adapter/common/placeholders/UriTransformer.java
@@ -66,7 +66,7 @@ public final class UriTransformer {
 
   private static String encodeValue(String value) {
     try {
-      return URLEncoder.encode(value, "UTF-8").replace("+", "%20");
+      return URLEncoder.encode(value, "UTF-8").replace("+", "%20").replace("%2F", "/");
     } catch (UnsupportedEncodingException var3) {
       throw new UnsupportedCharsetException("UTF-8");
     }

--- a/knotx-adapters/knotx-adapter-common/src/test/java/com/cognifide/knotx/adapter/common/placeholders/UriTransformerReplaceTest.java
+++ b/knotx-adapters/knotx-adapter-common/src/test/java/com/cognifide/knotx/adapter/common/placeholders/UriTransformerReplaceTest.java
@@ -88,7 +88,7 @@ public class UriTransformerReplaceTest {
             "/path/second.html/a."},
         // param
         {"/solr/search/{param.q}", "/c/d/s?q=my search is fetched from static getParams()",
-            "/solr/search/knot.x"},
+            "/solr/search/knot%20%26%20x"},
         // headers
         {"/solr/{header.authorizationId}/", "/c/d/s?q=my action from headers",
             "/solr/486434684345/"},
@@ -104,7 +104,7 @@ public class UriTransformerReplaceTest {
 
   private static MultiMap getParamsMultiMap() {
     MultiMap map = MultiMap.caseInsensitiveMultiMap();
-    map.add("q", "knot.x");
+    map.add("q", "knot & x");
     map.add("action", "/some/action/path");
     return map;
   }


### PR DESCRIPTION
value encoded using RFC standard with the exceptions:
space will be %20 (instead of +)
slash (/) will remain the same - as it's not in standard but widely used and supported