### PR TITLE
ActionKnotVerticle does not respect allowed.response.headers configuration

### DIFF
--- a/knotx-knots/knotx-knot-action/src/main/java/com/cognifide/knotx/knot/action/ActionKnotVerticle.java
+++ b/knotx-knots/knotx-knot-action/src/main/java/com/cognifide/knotx/knot/action/ActionKnotVerticle.java
@@ -143,7 +143,7 @@ public class ActionKnotVerticle extends AbstractKnot<ActionKnotConfiguration> {
               if (isNotOkStatus(clientResponse)) {
                 knotContext.clientResponse()
                     .setStatusCode(clientResponse.statusCode())
-                    .setHeaders(clientResponse.headers().addAll(getFilteredHeaders(clientResponse.headers(), adapterMetadata.getAllowedResponseHeaders())))
+                    .setHeaders(getFilteredHeaders(clientResponse.headers(), adapterMetadata.getAllowedResponseHeaders()))
                     .setBody(null);
                 knotContext.clearFragments();
 
@@ -174,8 +174,7 @@ public class ActionKnotVerticle extends AbstractKnot<ActionKnotConfiguration> {
                     .put("_response", clientResponse.toMetadataJson());
 
                 currentFragment.getContext().put("action", actionContext);
-                knotContext.clientResponse().setHeaders(
-                    clientResponse.headers().addAll(getFilteredHeaders(clientResponse.headers(), adapterMetadata.getAllowedResponseHeaders()))
+                knotContext.clientResponse().setHeaders(getFilteredHeaders(clientResponse.headers(), adapterMetadata.getAllowedResponseHeaders())
                 );
                 knotContext.fragments().ifPresent(this::processFragments);
                 knotContext.setTransition(DEFAULT_TRANSITION);


### PR DESCRIPTION
ActionKnotVerticle does not respect 'allowed.response.headers' configuration. Instead it returns all headers in clientResponse.

Following snippet is taken from ActionKnotVerticle:

```java
             knotContext.clientResponse().setHeaders(
                    clientResponse.headers().addAll(getFilteredHeaders(clientResponse.headers(), adapterMetadata.getAllowedResponseHeaders()))
                );
```


'clientResponse.headers().addAll ' part is not needed
