### PR TITLE
Fixed remote repository mock - change the way how mock files are bein…

### DIFF
--- a/knotx-example/knotx-mocks/src/main/java/com/cognifide/knotx/mocks/adapter/MockServiceHandler.java
+++ b/knotx-example/knotx-mocks/src/main/java/com/cognifide/knotx/mocks/adapter/MockServiceHandler.java
@@ -67,7 +67,7 @@ public class MockServiceHandler implements Handler<RoutingContext> {
         }
       } else {
         LOGGER.error("Unable to read file. {}", ar.cause());
-        context.response().setStatusCode(500).end();
+        context.fail(500);
       }
     });
   }


### PR DESCRIPTION
…g read to enable filesystem path access, instead of classpath only