### PR TITLE
#208 Changed log level from TRACE to INFO in all logback.xml files

### DIFF
--- a/knotx-adapters/knotx-adapter-action-http/src/main/resources/logback.xml
+++ b/knotx-adapters/knotx-adapter-action-http/src/main/resources/logback.xml
@@ -32,7 +32,7 @@
     <appender-ref ref="STDOUT"/>
   </logger>
 
-  <logger name="com.cognifide.knotx.adapter.action.http" level="TRACE" additivity="false">
+  <logger name="com.cognifide.knotx.adapter.action.http" level="INFO" additivity="false">
     <appender-ref ref="STDOUT"/>
   </logger>
 

--- a/knotx-adapters/knotx-adapter-action-http/src/test/java/com/cognifide/knotx/adapter/action/http/HttpClientFacadeTest.java
+++ b/knotx-adapters/knotx-adapter-action-http/src/test/java/com/cognifide/knotx/adapter/action/http/HttpClientFacadeTest.java
@@ -15,7 +15,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.cognifide.knotx.adapter.service.http;
+package com.cognifide.knotx.adapter.action.http;
 
 import com.cognifide.knotx.adapter.common.exception.UnsupportedServiceException;
 import com.cognifide.knotx.adapter.common.http.HttpClientFacade;

--- a/knotx-adapters/knotx-adapter-action-http/src/test/resources/logback-test.xml
+++ b/knotx-adapters/knotx-adapter-action-http/src/test/resources/logback-test.xml
@@ -28,7 +28,7 @@
     </layout>
   </appender>
 
-  <logger name="com.cognifide.knotx" level="TRACE"
+  <logger name="com.cognifide.knotx.action.http" level="INFO"
           additivity="false">
     <appender-ref ref="STDOUT"/>
   </logger>

--- a/knotx-adapters/knotx-adapter-common/src/test/resources/logback-test.xml
+++ b/knotx-adapters/knotx-adapter-common/src/test/resources/logback-test.xml
@@ -28,7 +28,7 @@
     </layout>
   </appender>
 
-  <logger name="com.cognifide.knotx" level="TRACE"
+  <logger name="com.cognifide.knotx.adapter.common" level="INFO"
           additivity="false">
     <appender-ref ref="STDOUT"/>
   </logger>

--- a/knotx-adapters/knotx-adapter-service-http/src/main/resources/logback.xml
+++ b/knotx-adapters/knotx-adapter-service-http/src/main/resources/logback.xml
@@ -32,7 +32,7 @@
     <appender-ref ref="STDOUT"/>
   </logger>
 
-  <logger name="com.cognifide.knotx.adapter.service.http" level="TRACE" additivity="false">
+  <logger name="com.cognifide.knotx.adapter.service.http" level="INFO" additivity="false">
     <appender-ref ref="STDOUT"/>
   </logger>
 

--- a/knotx-adapters/knotx-adapter-service-http/src/test/resources/logback-test.xml
+++ b/knotx-adapters/knotx-adapter-service-http/src/test/resources/logback-test.xml
@@ -28,7 +28,7 @@
     </layout>
   </appender>
 
-  <logger name="com.cognifide.knotx" level="TRACE"
+  <logger name="com.cognifide.knotx.adapter.service.http" level="TRACE"
           additivity="false">
     <appender-ref ref="STDOUT"/>
   </logger>

--- a/knotx-core/knotx-fragment-assembler/src/main/resources/logback.xml
+++ b/knotx-core/knotx-fragment-assembler/src/main/resources/logback.xml
@@ -32,7 +32,7 @@
     <appender-ref ref="STDOUT"/>
   </logger>
 
-  <logger name="com.cognifide.knotx.assembler" level="TRACE" additivity="false">
+  <logger name="com.cognifide.knotx.assembler" level="INFO" additivity="false">
     <appender-ref ref="STDOUT"/>
   </logger>
 

--- a/knotx-core/knotx-fragment-assembler/src/test/resources/logback.xml
+++ b/knotx-core/knotx-fragment-assembler/src/test/resources/logback.xml
@@ -32,7 +32,7 @@
     <appender-ref ref="STDOUT"/>
   </logger>
 
-  <logger name="com.cognifide.knotx.assembler" level="TRACE" additivity="false">
+  <logger name="com.cognifide.knotx.assembler" level="INFO" additivity="false">
     <appender-ref ref="STDOUT"/>
   </logger>
 

--- a/knotx-core/knotx-fragment-splitter/src/main/resources/logback.xml
+++ b/knotx-core/knotx-fragment-splitter/src/main/resources/logback.xml
@@ -32,7 +32,7 @@
     <appender-ref ref="STDOUT"/>
   </logger>
 
-  <logger name="com.cognifide.knotx.splitter" level="TRACE" additivity="false">
+  <logger name="com.cognifide.knotx.splitter" level="INFO" additivity="false">
     <appender-ref ref="STDOUT"/>
   </logger>
 

--- a/knotx-core/knotx-fragment-splitter/src/test/resources/logback-test.xml
+++ b/knotx-core/knotx-fragment-splitter/src/test/resources/logback-test.xml
@@ -28,7 +28,7 @@
     </layout>
   </appender>
 
-  <logger name="com.cognifide.knotx.splitter" level="TRACE"
+  <logger name="com.cognifide.knotx.splitter" level="INFO"
           additivity="false">
     <appender-ref ref="STDOUT"/>
   </logger>

--- a/knotx-core/knotx-repository/knotx-repository-connector-filesystem/src/main/resources/logback.xml
+++ b/knotx-core/knotx-repository/knotx-repository-connector-filesystem/src/main/resources/logback.xml
@@ -32,7 +32,7 @@
     <appender-ref ref="STDOUT"/>
   </logger>
 
-  <logger name="com.cognifide.knotx.repository" level="TRACE" additivity="false">
+  <logger name="com.cognifide.knotx.repository" level="INFO" additivity="false">
     <appender-ref ref="STDOUT"/>
   </logger>
 

--- a/knotx-core/knotx-repository/knotx-repository-connector-http/src/main/resources/logback.xml
+++ b/knotx-core/knotx-repository/knotx-repository-connector-http/src/main/resources/logback.xml
@@ -32,7 +32,7 @@
     <appender-ref ref="STDOUT"/>
   </logger>
 
-  <logger name="com.cognifide.knotx.repository" level="TRACE" additivity="false">
+  <logger name="com.cognifide.knotx.repository" level="INFO" additivity="false">
     <appender-ref ref="STDOUT"/>
   </logger>
 

--- a/knotx-core/knotx-server/src/main/resources/logback.xml
+++ b/knotx-core/knotx-server/src/main/resources/logback.xml
@@ -32,7 +32,7 @@
     <appender-ref ref="STDOUT"/>
   </logger>
 
-  <logger name="com.cognifide.knotx.server" level="TRACE" additivity="false">
+  <logger name="com.cognifide.knotx.server" level="INFO" additivity="false">
     <appender-ref ref="STDOUT"/>
   </logger>
 

--- a/knotx-core/knotx-server/src/test/resources/logback.xml
+++ b/knotx-core/knotx-server/src/test/resources/logback.xml
@@ -28,7 +28,7 @@
     </layout>
   </appender>
 
-  <logger name="com.cognifide.knotx" level="TRACE"
+  <logger name="com.cognifide.knotx" level="INFO"
           additivity="false">
     <appender-ref ref="STDOUT"/>
   </logger>

--- a/knotx-example/knotx-example-monolith/src/main/resources/logback.xml
+++ b/knotx-example/knotx-example-monolith/src/main/resources/logback.xml
@@ -28,7 +28,7 @@
     </layout>
   </appender>
 
-  <logger name="com.cognifide.knotx" level="TRACE"
+  <logger name="com.cognifide.knotx" level="INFO"
           additivity="false">
     <appender-ref ref="STDOUT"/>
   </logger>

--- a/knotx-example/knotx-example-monolith/src/test/resources/logback-test.xml
+++ b/knotx-example/knotx-example-monolith/src/test/resources/logback-test.xml
@@ -28,7 +28,7 @@
     </layout>
   </appender>
 
-  <logger name="com.cognifide.knotx" level="TRACE"
+  <logger name="com.cognifide.knotx.example.monolith" level="INFO"
           additivity="false">
     <appender-ref ref="STDOUT"/>
   </logger>

--- a/knotx-example/knotx-mocks/src/main/resources/logback.xml
+++ b/knotx-example/knotx-mocks/src/main/resources/logback.xml
@@ -33,7 +33,7 @@
     <appender-ref ref="STDOUT"/>
   </logger>
 
-  <logger name="com.cognifide.knotx.engine" level="TRACE"
+  <logger name="com.cognifide.knotx.engine" level="INFO"
           additivity="false">
     <appender-ref ref="STDOUT"/>
   </logger>

--- a/knotx-knots/knotx-knot-action/src/main/resources/logback.xml
+++ b/knotx-knots/knotx-knot-action/src/main/resources/logback.xml
@@ -32,7 +32,7 @@
     <appender-ref ref="STDOUT"/>
   </logger>
 
-  <logger name="com.cognifide.knotx.knot.action" level="TRACE" additivity="false">
+  <logger name="com.cognifide.knotx.knot.action" level="INFO" additivity="false">
     <appender-ref ref="STDOUT"/>
   </logger>
 

--- a/knotx-knots/knotx-knot-action/src/test/resources/logback-test.xml
+++ b/knotx-knots/knotx-knot-action/src/test/resources/logback-test.xml
@@ -28,7 +28,7 @@
     </layout>
   </appender>
 
-  <logger name="com.cognifide.knotx.knot.action" level="TRACE"
+  <logger name="com.cognifide.knotx.knot.action" level="INFO"
           additivity="false">
     <appender-ref ref="STDOUT"/>
   </logger>

--- a/knotx-knots/knotx-knot-handlebars/src/main/resources/logback.xml
+++ b/knotx-knots/knotx-knot-handlebars/src/main/resources/logback.xml
@@ -32,7 +32,7 @@
     <appender-ref ref="STDOUT"/>
   </logger>
 
-  <logger name="com.cognifide.knotx.knot.templating" level="TRACE" additivity="false">
+  <logger name="com.cognifide.knotx.knot.templating" level="INFO" additivity="false">
     <appender-ref ref="STDOUT"/>
   </logger>
 

--- a/knotx-knots/knotx-knot-handlebars/src/test/resources/logback-test.xml
+++ b/knotx-knots/knotx-knot-handlebars/src/test/resources/logback-test.xml
@@ -28,7 +28,7 @@
     </layout>
   </appender>
 
-  <logger name="com.cognifide.knotx.knot.service" level="TRACE"
+  <logger name="com.cognifide.knotx.knot.templating" level="TEST"
           additivity="false">
     <appender-ref ref="STDOUT"/>
   </logger>

--- a/knotx-knots/knotx-knot-service/src/main/resources/logback.xml
+++ b/knotx-knots/knotx-knot-service/src/main/resources/logback.xml
@@ -32,7 +32,7 @@
     <appender-ref ref="STDOUT"/>
   </logger>
 
-  <logger name="com.cognifide.knotx.knot.service" level="TRACE" additivity="false">
+  <logger name="com.cognifide.knotx.knot.service" level="INFO" additivity="false">
     <appender-ref ref="STDOUT"/>
   </logger>
 

--- a/knotx-knots/knotx-knot-service/src/test/resources/logback-test.xml
+++ b/knotx-knots/knotx-knot-service/src/test/resources/logback-test.xml
@@ -28,7 +28,7 @@
     </layout>
   </appender>
 
-  <logger name="com.cognifide.knotx.knot.service" level="TRACE"
+  <logger name="com.cognifide.knotx.knot.service" level="INFO"
           additivity="false">
     <appender-ref ref="STDOUT"/>
   </logger>

--- a/knotx-standalone/src/main/resources/logback.xml
+++ b/knotx-standalone/src/main/resources/logback.xml
@@ -28,7 +28,7 @@
     </layout>
   </appender>
 
-  <logger name="com.cognifide.knotx" level="TRACE"
+  <logger name="com.cognifide.knotx" level="INFO"
           additivity="false">
     <appender-ref ref="STDOUT"/>
   </logger>


### PR DESCRIPTION
Updated `logback.xml` files to use the `INFO` log level as opposed to `TRACE`, as described in #208 

Not sure about the `logback-test.xml` files. Do we want those updated too?

---

I hereby agree to the terms of the Knot.x Contributor License Agreement.