### PR TITLE
Fixed #237 - Do not call Fragment assembler if Knot processing result…

### DIFF
--- a/knotx-server/src/test/resources/test.io.knotx.KnotxServer.json
+++ b/knotx-server/src/test/resources/test.io.knotx.KnotxServer.json
@@ -41,7 +41,8 @@
         "x-original-requested-uri",
         "x-solr-core-key",
         "x-language-code",
-        "x-requested-with"
+        "x-requested-with",
+        "location"
       ],
       "repositories": [
         {


### PR DESCRIPTION
Fixed #237 - Do not call Fragment assembler if Knot processing finished with response Code other than 200
- Added unit test to cover this bug