### PR TITLE
Jsoup usages unit tests

### DIFF
--- a/knotx-junit/pom.xml
+++ b/knotx-junit/pom.xml
@@ -54,6 +54,16 @@
       <artifactId>system-rules</artifactId>
       <scope>provided</scope>
     </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-all</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.googlecode.zohhak</groupId>
+      <artifactId>zohhak</artifactId>
+      <scope>provided</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/knotx-junit/src/main/java/io/knotx/junit/coercers/KnotxCoercers.java
+++ b/knotx-junit/src/main/java/io/knotx/junit/coercers/KnotxCoercers.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2016 Cognifide Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.knotx.junit.coercers;
+
+import static org.mockito.Mockito.when;
+
+import io.knotx.dataobjects.Fragment;
+import io.knotx.junit.util.FileReader;
+import io.vertx.core.json.JsonObject;
+import java.io.IOException;
+import org.mockito.Mockito;
+
+public class KnotxCoercers {
+
+  public Fragment provideFragment(String fragmentContentFile) throws IOException {
+    final String fragmentContent = FileReader.readText(fragmentContentFile);
+    Fragment fragmentMock = Mockito.mock(Fragment.class);
+    when(fragmentMock.content()).thenReturn(fragmentContent);
+    return fragmentMock;
+  }
+
+  public JsonObject provideJsonObjectFromString(String input) {
+    return new JsonObject(input);
+  }
+
+}

--- a/knotx-knot/knotx-knot-fragment-assembler/pom.xml
+++ b/knotx-knot/knotx-knot-fragment-assembler/pom.xml
@@ -47,6 +47,22 @@
       <artifactId>vertx-unit</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-all</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.googlecode.zohhak</groupId>
+      <artifactId>zohhak</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.hamcrest</groupId>
+      <artifactId>hamcrest-all</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>uk.co.datumedge</groupId>
+      <artifactId>hamcrest-json</artifactId>
+    </dependency>
+    <dependency>
       <groupId>io.knotx</groupId>
       <artifactId>knotx-junit</artifactId>
       <version>${project.version}</version>

--- a/knotx-knot/knotx-knot-fragment-assembler/src/test/java/io/knotx/knot/assembler/impl/UnprocessedFragmentStrategyTest.java
+++ b/knotx-knot/knotx-knot-fragment-assembler/src/test/java/io/knotx/knot/assembler/impl/UnprocessedFragmentStrategyTest.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (C) 2016 Cognifide Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.knotx.knot.assembler.impl;
+
+import static org.hamcrest.Matchers.equalToIgnoringWhiteSpace;
+import static org.junit.Assert.assertThat;
+
+import com.googlecode.zohhak.api.Configure;
+import com.googlecode.zohhak.api.TestWith;
+import com.googlecode.zohhak.api.runners.ZohhakRunner;
+import io.knotx.dataobjects.Fragment;
+import io.knotx.junit.coercers.KnotxCoercers;
+import io.knotx.junit.util.FileReader;
+import org.junit.runner.RunWith;
+
+@RunWith(ZohhakRunner.class)
+@Configure(separator = ";", coercers = KnotxCoercers.class)
+public class UnprocessedFragmentStrategyTest {
+
+  @TestWith({
+      "simple_snippet.txt;simple_snippet.txt",
+      "raw_fragment.txt;raw_fragment.txt"
+  })
+  public void asIs_whenFragment_expectIgnoredContent(Fragment fragment,
+      String expectedContentFileName) throws Exception {
+    final String unwrappedContent = UnprocessedFragmentStrategy.AS_IS.get(fragment);
+    final String expectedContent = FileReader.readText(expectedContentFileName);
+
+    assertThat(unwrappedContent, equalToIgnoringWhiteSpace(expectedContent));
+  }
+
+  @TestWith({
+      "simple_snippet.txt;simple_snippet-expected_unwrapped_content.txt",
+      "big_snippet.txt;big_snippet-expected_unwrapped_content.txt"
+  })
+  public void unwrap_withFragment_expectDefinedContentWithComments(Fragment fragment,
+      String expectedContentFileName) throws Exception {
+    final String unwrappedContent = UnprocessedFragmentStrategy.UNWRAP.get(fragment);
+    final String expectedContent = FileReader.readText(expectedContentFileName);
+
+    assertThat(unwrappedContent, equalToIgnoringWhiteSpace(expectedContent));
+  }
+
+  @TestWith({
+      "simple_snippet.txt;simple_snippet-expected_ignored_content.txt",
+      "raw_fragment.txt;raw_fragment.txt" //when fragment is a raw fragment, it is not ignored
+  })
+  public void ignore_whenFragment_expectIgnoredContent(Fragment fragment,
+      String expectedContentFileName) throws Exception {
+    final String unwrappedContent = UnprocessedFragmentStrategy.IGNORE.get(fragment);
+    final String expectedContent = FileReader.readText(expectedContentFileName);
+
+    assertThat(unwrappedContent, equalToIgnoringWhiteSpace(expectedContent));
+  }
+
+
+}

--- a/knotx-knot/knotx-knot-fragment-assembler/src/test/resources/big_snippet-expected_unwrapped_content.txt
+++ b/knotx-knot/knotx-knot-fragment-assembler/src/test/resources/big_snippet-expected_unwrapped_content.txt
@@ -1,0 +1,18 @@
+<!-- SNIPPET UNWRAPED START -->
+<div class="col-md-4">
+  <h2>Snippet1 - {{_result.message}}</h2>
+  <div>Snippet1 - {{_result.body.a}}</div>
+  <div>{{#bold}}Custom Handlebars helper{{/bold}}</div>
+</div>
+<div class="col-md-4">
+  <h2>Snippet1 - {{second._result.message}}</h2>
+  <div>Snippet1 - {{second._result.body.a}}</div>
+  {{#string_equals second._response.statusCode "200"}}
+  <div>Success! Status code : {{second._response.statusCode}}</div>
+  {{/string_equals}}
+</div>
+<div class="col-md-4">
+  <h2>Snippet1 - {{third._result.message}}</h2>
+  <div>Snippet1 - {{third._result.body.a}}</div>
+</div>
+<!-- SNIPPET UNWRAPED STOP -->

--- a/knotx-knot/knotx-knot-fragment-assembler/src/test/resources/big_snippet.txt
+++ b/knotx-knot/knotx-knot-fragment-assembler/src/test/resources/big_snippet.txt
@@ -1,0 +1,22 @@
+<script data-knotx-knots="services,handlebars"
+        data-knotx-service="first-service"
+        data-knotx-service-second="second-service"
+        data-knotx-service-third="third-service"
+        type="text/knotx-snippet">
+  <div class="col-md-4">
+    <h2>Snippet1 - {{_result.message}}</h2>
+    <div>Snippet1 - {{_result.body.a}}</div>
+    <div>{{#bold}}Custom Handlebars helper{{/bold}}</div>
+  </div>
+  <div class="col-md-4">
+    <h2>Snippet1 - {{second._result.message}}</h2>
+    <div>Snippet1 - {{second._result.body.a}}</div>
+    {{#string_equals second._response.statusCode "200"}}
+    <div>Success! Status code : {{second._response.statusCode}}</div>
+    {{/string_equals}}
+  </div>
+  <div class="col-md-4">
+    <h2>Snippet1 - {{third._result.message}}</h2>
+    <div>Snippet1 - {{third._result.body.a}}</div>
+  </div>
+</script>

--- a/knotx-knot/knotx-knot-fragment-assembler/src/test/resources/raw_fragment.txt
+++ b/knotx-knot/knotx-knot-fragment-assembler/src/test/resources/raw_fragment.txt
@@ -1,0 +1,16 @@
+<div class="row">
+  <div class="col-md-12">
+    <div class="jumbotron">
+      <h2>
+        Hello Knot.x - reactive micro-service assembler world!
+      </h2>
+      <p>
+        This template is served from the <strong>local</strong> repository.
+      </p>
+      <p>
+        <a class="btn btn-primary btn-large"
+           href="https://github.com/Cognifide/knotx">Learn more</a>
+      </p>
+    </div>
+  </div>
+</div>

--- a/knotx-knot/knotx-knot-fragment-assembler/src/test/resources/simple_snippet-expected_ignored_content.txt
+++ b/knotx-knot/knotx-knot-fragment-assembler/src/test/resources/simple_snippet-expected_ignored_content.txt
@@ -1,0 +1,1 @@
+<!-- SNIPPET IGNORED -->

--- a/knotx-knot/knotx-knot-fragment-assembler/src/test/resources/simple_snippet-expected_unwrapped_content.txt
+++ b/knotx-knot/knotx-knot-fragment-assembler/src/test/resources/simple_snippet-expected_unwrapped_content.txt
@@ -1,0 +1,3 @@
+<!-- SNIPPET UNWRAPED START -->
+<h2>{{_result.message}}</h2>
+<!-- SNIPPET UNWRAPED STOP -->

--- a/knotx-knot/knotx-knot-fragment-assembler/src/test/resources/simple_snippet.txt
+++ b/knotx-knot/knotx-knot-fragment-assembler/src/test/resources/simple_snippet.txt
@@ -1,0 +1,7 @@
+<script
+  data-knotx-knots="services"
+  data-knotx-service="first-service"
+  data-knotx-params='{"path":"/overridden/path"}'
+  type="text/knotx-snippet">
+  <h2>{{_result.message}}</h2>
+</script>

--- a/knotx-knot/knotx-knot-handlebars/pom.xml
+++ b/knotx-knot/knotx-knot-handlebars/pom.xml
@@ -79,6 +79,10 @@
       <artifactId>vertx-unit</artifactId>
     </dependency>
     <dependency>
+      <groupId>com.googlecode.zohhak</groupId>
+      <artifactId>zohhak</artifactId>
+    </dependency>
+    <dependency>
       <groupId>io.knotx</groupId>
       <artifactId>knotx-junit</artifactId>
       <version>${project.version}</version>

--- a/knotx-knot/knotx-knot-handlebars/src/main/java/io/knotx/knot/templating/impl/FragmentContentExtractor.java
+++ b/knotx-knot/knotx-knot-handlebars/src/main/java/io/knotx/knot/templating/impl/FragmentContentExtractor.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2016 Cognifide Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.knotx.knot.templating.impl;
+
+import io.knotx.dataobjects.Fragment;
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
+import org.jsoup.nodes.Element;
+
+final class FragmentContentExtractor {
+
+  private FragmentContentExtractor() {
+    //util class
+  }
+
+  static String getUnwrappedContent(Fragment fragment) {
+    Document document = Jsoup.parseBodyFragment(fragment.content());
+    Element scriptTag = document.body().child(0);
+    return scriptTag.unwrap().toString();
+  }
+}

--- a/knotx-knot/knotx-knot-handlebars/src/main/java/io/knotx/knot/templating/impl/HandlebarsFragment.java
+++ b/knotx-knot/knotx-knot-handlebars/src/main/java/io/knotx/knot/templating/impl/HandlebarsFragment.java
@@ -15,18 +15,15 @@
  */
 package io.knotx.knot.templating.impl;
 
-import io.knotx.dataobjects.Fragment;
 import com.github.jknack.handlebars.Context;
 import com.github.jknack.handlebars.Handlebars;
 import com.github.jknack.handlebars.Template;
+import io.knotx.dataobjects.Fragment;
 import io.knotx.knot.templating.handlebars.JsonObjectValueResolver;
 import io.vertx.core.logging.Logger;
 import io.vertx.core.logging.LoggerFactory;
 import java.io.IOException;
 import org.apache.commons.lang3.StringUtils;
-import org.jsoup.Jsoup;
-import org.jsoup.nodes.Document;
-import org.jsoup.nodes.Element;
 
 class HandlebarsFragment {
 
@@ -40,7 +37,7 @@ class HandlebarsFragment {
 
   HandlebarsFragment(Fragment fragment) {
     this.fragment = fragment;
-    this.unwrappedContent = getUnwrappedContent(fragment);
+    this.unwrappedContent = FragmentContentExtractor.getUnwrappedContent(fragment);
   }
 
   String compileWith(Handlebars handlebars) {
@@ -58,12 +55,6 @@ class HandlebarsFragment {
       LOGGER.error("Could not process fragment [{}]", fragment.content(), e);
       throw new IllegalStateException("Handlebars fragment can not be evaluated correctly.");
     }
-  }
-
-  private String getUnwrappedContent(Fragment fragment) {
-    Document document = Jsoup.parseBodyFragment(fragment.content());
-    Element scriptTag = document.body().child(0);
-    return scriptTag.unwrap().toString();
   }
 
 }

--- a/knotx-knot/knotx-knot-handlebars/src/test/java/io/knotx/knot/templating/impl/FragmentContentExtractorTest.java
+++ b/knotx-knot/knotx-knot-handlebars/src/test/java/io/knotx/knot/templating/impl/FragmentContentExtractorTest.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) 2016 Cognifide Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.knotx.knot.templating.impl;
+
+import static org.hamcrest.Matchers.equalToIgnoringWhiteSpace;
+import static org.junit.Assert.assertThat;
+
+import com.googlecode.zohhak.api.Configure;
+import com.googlecode.zohhak.api.TestWith;
+import com.googlecode.zohhak.api.runners.ZohhakRunner;
+import io.knotx.dataobjects.Fragment;
+import io.knotx.junit.coercers.KnotxCoercers;
+import io.knotx.junit.util.FileReader;
+import org.junit.runner.RunWith;
+
+@RunWith(ZohhakRunner.class)
+@Configure(separator = ";", coercers = KnotxCoercers.class)
+public class FragmentContentExtractorTest {
+
+  @TestWith({
+      "simple_snippet.txt;simple_snippet-expected_content.txt",
+      "big_snippet.txt;big_snippet-expected_content.txt"
+  })
+  public void getUnwrappedContent_withFragment_expectDefinedContent(Fragment fragment,
+      String expectedContentFileName) throws Exception {
+
+    final String expectedContent = FileReader.readText(expectedContentFileName);
+    final String unwrappedContent = FragmentContentExtractor.getUnwrappedContent(fragment);
+    assertThat(unwrappedContent, equalToIgnoringWhiteSpace(expectedContent));
+  }
+}

--- a/knotx-knot/knotx-knot-handlebars/src/test/resources/big_snippet-expected_content.txt
+++ b/knotx-knot/knotx-knot-handlebars/src/test/resources/big_snippet-expected_content.txt
@@ -1,0 +1,16 @@
+<div class="col-md-4">
+  <h2>Snippet1 - {{_result.message}}</h2>
+  <div>Snippet1 - {{_result.body.a}}</div>
+  <div>{{#bold}}Custom Handlebars helper{{/bold}}</div>
+</div>
+<div class="col-md-4">
+  <h2>Snippet1 - {{second._result.message}}</h2>
+  <div>Snippet1 - {{second._result.body.a}}</div>
+  {{#string_equals second._response.statusCode "200"}}
+  <div>Success! Status code : {{second._response.statusCode}}</div>
+  {{/string_equals}}
+</div>
+<div class="col-md-4">
+  <h2>Snippet1 - {{third._result.message}}</h2>
+  <div>Snippet1 - {{third._result.body.a}}</div>
+</div>

--- a/knotx-knot/knotx-knot-handlebars/src/test/resources/big_snippet.txt
+++ b/knotx-knot/knotx-knot-handlebars/src/test/resources/big_snippet.txt
@@ -1,0 +1,22 @@
+<script data-knotx-knots="services,handlebars"
+        data-knotx-service="first-service"
+        data-knotx-service-second="second-service"
+        data-knotx-service-third="third-service"
+        type="text/knotx-snippet">
+  <div class="col-md-4">
+    <h2>Snippet1 - {{_result.message}}</h2>
+    <div>Snippet1 - {{_result.body.a}}</div>
+    <div>{{#bold}}Custom Handlebars helper{{/bold}}</div>
+  </div>
+  <div class="col-md-4">
+    <h2>Snippet1 - {{second._result.message}}</h2>
+    <div>Snippet1 - {{second._result.body.a}}</div>
+    {{#string_equals second._response.statusCode "200"}}
+    <div>Success! Status code : {{second._response.statusCode}}</div>
+    {{/string_equals}}
+  </div>
+  <div class="col-md-4">
+    <h2>Snippet1 - {{third._result.message}}</h2>
+    <div>Snippet1 - {{third._result.body.a}}</div>
+  </div>
+</script>

--- a/knotx-knot/knotx-knot-handlebars/src/test/resources/simple_snippet-expected_content.txt
+++ b/knotx-knot/knotx-knot-handlebars/src/test/resources/simple_snippet-expected_content.txt
@@ -1,0 +1,1 @@
+<h2>{{_result.message}}</h2>

--- a/knotx-knot/knotx-knot-handlebars/src/test/resources/simple_snippet.txt
+++ b/knotx-knot/knotx-knot-handlebars/src/test/resources/simple_snippet.txt
@@ -1,0 +1,7 @@
+<script
+  data-knotx-knots="services"
+  data-knotx-service="first-service"
+  data-knotx-params='{"path":"/overridden/path"}'
+  type="text/knotx-snippet">
+  <h2>{{_result.message}}</h2>
+</script>

--- a/knotx-knot/knotx-knot-service/pom.xml
+++ b/knotx-knot/knotx-knot-service/pom.xml
@@ -63,6 +63,14 @@
       <artifactId>vertx-unit</artifactId>
     </dependency>
     <dependency>
+      <groupId>com.googlecode.zohhak</groupId>
+      <artifactId>zohhak</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>uk.co.datumedge</groupId>
+      <artifactId>hamcrest-json</artifactId>
+    </dependency>
+    <dependency>
       <groupId>io.knotx</groupId>
       <artifactId>knotx-junit</artifactId>
       <version>${project.version}</version>

--- a/knotx-knot/knotx-knot-service/src/main/java/io/knotx/knot/service/impl/FragmentContext.java
+++ b/knotx-knot/knotx-knot-service/src/main/java/io/knotx/knot/service/impl/FragmentContext.java
@@ -34,7 +34,7 @@ class FragmentContext {
   private static final String DATA_PARAMS = "data-knotx-params.*";
 
   private Fragment fragment;
-  private List<ServiceEntry> services;
+  List<ServiceEntry> services;
 
   private FragmentContext() {
   }
@@ -57,15 +57,18 @@ class FragmentContext {
             .toMap(attribute -> ServiceAttributeUtil.extractNamespace(attribute.getKey()),
                 Function.identity()));
 
-    return empty().fragment(fragment).services(serviceAttributes.entrySet().stream()
-        .map(entry -> new ServiceEntry(entry.getValue(), paramsAttributes.get(entry.getKey())))
-        .collect(Collectors.toList()));
+    return empty()
+        .fragment(fragment)
+        .services(
+            serviceAttributes.entrySet().stream()
+            .map(entry -> new ServiceEntry(entry.getValue(), paramsAttributes.get(entry.getKey())))
+            .collect(Collectors.toList())
+        );
   }
 
   static FragmentContext empty() {
     return new FragmentContext();
   }
-
 
   Fragment fragment() {
     return fragment;

--- a/knotx-knot/knotx-knot-service/src/test/java/io/knotx/knot/service/impl/FragmentContextTest.java
+++ b/knotx-knot/knotx-knot-service/src/test/java/io/knotx/knot/service/impl/FragmentContextTest.java
@@ -17,23 +17,19 @@ package io.knotx.knot.service.impl;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.mockito.Mockito.when;
 import static uk.co.datumedge.hamcrest.json.SameJSONAs.sameJSONAs;
 
-import com.googlecode.zohhak.api.Coercion;
 import com.googlecode.zohhak.api.Configure;
 import com.googlecode.zohhak.api.TestWith;
 import com.googlecode.zohhak.api.runners.ZohhakRunner;
 import io.knotx.dataobjects.Fragment;
-import io.knotx.junit.util.FileReader;
+import io.knotx.junit.coercers.KnotxCoercers;
 import io.knotx.knot.service.service.ServiceEntry;
 import io.vertx.core.json.JsonObject;
-import java.io.IOException;
 import org.junit.runner.RunWith;
-import org.mockito.Mockito;
 
 @RunWith(ZohhakRunner.class)
-@Configure(separator = ";")
+@Configure(separator = ";", coercers = KnotxCoercers.class)
 public class FragmentContextTest {
 
   @TestWith({
@@ -79,16 +75,4 @@ public class FragmentContextTest {
     );
   }
 
-  @Coercion
-  public JsonObject provideParameters(String paramsAsJsonObject) throws IOException {
-    return new JsonObject(paramsAsJsonObject);
-  }
-
-  @Coercion
-  public Fragment provideFragment(String fragmentContentFile) throws IOException {
-    final String fragmentContent = FileReader.readText(fragmentContentFile);
-    Fragment fragmentMock = Mockito.mock(Fragment.class);
-    when(fragmentMock.content()).thenReturn(fragmentContent);
-    return fragmentMock;
-  }
 }

--- a/knotx-knot/knotx-knot-service/src/test/java/io/knotx/knot/service/impl/FragmentContextTest.java
+++ b/knotx-knot/knotx-knot-service/src/test/java/io/knotx/knot/service/impl/FragmentContextTest.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright (C) 2016 Cognifide Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.knotx.knot.service.impl;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.Mockito.when;
+import static uk.co.datumedge.hamcrest.json.SameJSONAs.sameJSONAs;
+
+import com.googlecode.zohhak.api.Coercion;
+import com.googlecode.zohhak.api.Configure;
+import com.googlecode.zohhak.api.TestWith;
+import com.googlecode.zohhak.api.runners.ZohhakRunner;
+import io.knotx.dataobjects.Fragment;
+import io.knotx.junit.util.FileReader;
+import io.knotx.knot.service.service.ServiceEntry;
+import io.vertx.core.json.JsonObject;
+import java.io.IOException;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+
+@RunWith(ZohhakRunner.class)
+@Configure(separator = ";")
+public class FragmentContextTest {
+
+  @TestWith({
+      "snippet_one_service_no_params.txt;{}",
+      "snippet_one_service_invalid_params_bound.txt;{}",
+      "snippet_one_service_one_param.txt;{\"path\":\"/overridden/path\"}",
+      "snippet_one_service_many_params.txt;{\"path\":\"/overridden/path\",\"anotherParam\":\"someValue\"}"
+  })
+  public void from_whenFragmentContainsOneService_expectFragmentContextWithExtractedParamsParams(
+      Fragment fragment, String expectedParameters) throws Exception {
+
+    final FragmentContext fragmentContext = FragmentContext.from(fragment);
+    final ServiceEntry serviceEntry = fragmentContext.services.get(0);
+    assertThat(serviceEntry.getParams().toString(), sameJSONAs(expectedParameters));
+  }
+
+  @TestWith({
+      "snippet_one_service_no_params.txt;1",
+      "snippet_one_service_one_param.txt;1",
+      "snippet_one_service_many_params.txt;1",
+      "snippet_two_services.txt;2",
+      "snippet_five_services.txt;5"
+  })
+  public void from_whenFragmentContainsServices_expectFragmentContextWithProperNumberOfServicesExtracted(
+      Fragment fragment, int numberOfExpectedServices) throws Exception {
+
+    final FragmentContext fragmentContext = FragmentContext.from(fragment);
+    assertThat(fragmentContext.services.size(), is(numberOfExpectedServices));
+  }
+
+  @TestWith({
+      "snippet_two_services_with_params.txt;{\"first\":{\"first-service-key\":\"first-service-value\"},\"second\":{\"second-service-key\":\"second-service-value\"}}",
+      "snippet_four_services_with_params_and_extra_param.txt;{\"a\":{\"a\":\"a\"},\"b\":{\"b\":\"b\"},\"c\":{\"c\":\"c\"},\"d\":{\"d\":\"d\"}}"
+  })
+  public void from_whenFragmentContainsServices_expectProperlyAssignedParams(
+      Fragment fragment, JsonObject parameters) throws Exception {
+
+    final FragmentContext fragmentContext = FragmentContext.from(fragment);
+    fragmentContext.services.forEach(serviceEntry ->
+        assertThat(serviceEntry.getParams().toString(),
+            sameJSONAs(parameters.getJsonObject(serviceEntry.getNamespace()).toString())
+        )
+    );
+  }
+
+  @Coercion
+  public JsonObject provideParameters(String paramsAsJsonObject) throws IOException {
+    return new JsonObject(paramsAsJsonObject);
+  }
+
+  @Coercion
+  public Fragment provideFragment(String fragmentContentFile) throws IOException {
+    final String fragmentContent = FileReader.readText(fragmentContentFile);
+    Fragment fragmentMock = Mockito.mock(Fragment.class);
+    when(fragmentMock.content()).thenReturn(fragmentContent);
+    return fragmentMock;
+  }
+}

--- a/knotx-knot/knotx-knot-service/src/test/resources/snippet_five_services.txt
+++ b/knotx-knot/knotx-knot-service/src/test/resources/snippet_five_services.txt
@@ -1,0 +1,10 @@
+<script
+  data-knotx-knots="services"
+  data-knotx-service-a="a-service"
+  data-knotx-service-b="b-service"
+  data-knotx-service-c="c-service"
+  data-knotx-service-d="d-service"
+  data-knotx-service-e="e-service"
+  type="text/knotx-snippet">
+  <h2>{{_result.message}}</h2>
+</script>

--- a/knotx-knot/knotx-knot-service/src/test/resources/snippet_four_services_with_params_and_extra_param.txt
+++ b/knotx-knot/knotx-knot-service/src/test/resources/snippet_four_services_with_params_and_extra_param.txt
@@ -1,0 +1,14 @@
+<script
+  data-knotx-knots="services"
+  data-knotx-service-a="a-service"
+  data-knotx-params-a='{"a":"a"}'
+  data-knotx-service-b="b-service"
+  data-knotx-params-b='{"b":"b"}'
+  data-knotx-service-c="c-service"
+  data-knotx-params-c='{"c":"c"}'
+  data-knotx-service-d="d-service"
+  data-knotx-params-d='{"d":"d"}'
+  data-knotx-params-unbound='{"e":"e"}'
+  type="text/knotx-snippet">
+  <h2>{{_result.message}}</h2>
+</script>

--- a/knotx-knot/knotx-knot-service/src/test/resources/snippet_one_service_invalid_params_bound.txt
+++ b/knotx-knot/knotx-knot-service/src/test/resources/snippet_one_service_invalid_params_bound.txt
@@ -1,0 +1,7 @@
+<script
+  data-knotx-knots="services"
+  data-knotx-service-first="first-service"
+  data-knotx-params='{"path":"/overridden/path"}'
+  type="text/knotx-snippet">
+  <h2>{{_result.message}}</h2>
+</script>

--- a/knotx-knot/knotx-knot-service/src/test/resources/snippet_one_service_many_params.txt
+++ b/knotx-knot/knotx-knot-service/src/test/resources/snippet_one_service_many_params.txt
@@ -1,0 +1,8 @@
+<script
+  data-knotx-knots="services"
+  data-knotx-service="first-service"
+  data-knotx-params='{"path":"/overridden/path","anotherParam":"someValue"}'
+  data-knotx-params-undefined='{"notBound":"toAnyService"}'
+  type="text/knotx-snippet">
+  <h2>{{_result.message}}</h2>
+</script>

--- a/knotx-knot/knotx-knot-service/src/test/resources/snippet_one_service_no_params.txt
+++ b/knotx-knot/knotx-knot-service/src/test/resources/snippet_one_service_no_params.txt
@@ -1,0 +1,6 @@
+<script
+  data-knotx-knots="services"
+  data-knotx-service="first-service"
+  type="text/knotx-snippet">
+  <h2>{{_result.message}}</h2>
+</script>

--- a/knotx-knot/knotx-knot-service/src/test/resources/snippet_one_service_one_param.txt
+++ b/knotx-knot/knotx-knot-service/src/test/resources/snippet_one_service_one_param.txt
@@ -1,0 +1,7 @@
+<script
+  data-knotx-knots="services"
+  data-knotx-service="first-service"
+  data-knotx-params='{"path":"/overridden/path"}'
+  type="text/knotx-snippet">
+  <h2>{{_result.message}}</h2>
+</script>

--- a/knotx-knot/knotx-knot-service/src/test/resources/snippet_two_services.txt
+++ b/knotx-knot/knotx-knot-service/src/test/resources/snippet_two_services.txt
@@ -1,0 +1,7 @@
+<script
+  data-knotx-knots="services"
+  data-knotx-service="no-name-service"
+  data-knotx-service-named="named-service"
+  type="text/knotx-snippet">
+  <h2>{{_result.message}}</h2>
+</script>

--- a/knotx-knot/knotx-knot-service/src/test/resources/snippet_two_services_with_params.txt
+++ b/knotx-knot/knotx-knot-service/src/test/resources/snippet_two_services_with_params.txt
@@ -1,0 +1,9 @@
+<script
+  data-knotx-knots="services"
+  data-knotx-service-first="first-service"
+  data-knotx-params-first='{"first-service-key":"first-service-value"}'
+  data-knotx-service-second="second-service"
+  data-knotx-params-second='{"second-service-key":"second-service-value"}'
+  type="text/knotx-snippet">
+  <h2>{{_result.message}}</h2>
+</script>


### PR DESCRIPTION
Some `JSoup` usages covered with unit tests in order to better refactor Knot.x during #256 .

_Target of this merge is for code review clarity `multimap-utils-unittests-and-javadoc-fixes` branch. Please change the target to  `master` after #255 is merged._

---

I hereby agree to the terms of the Knot.x Contributor License Agreement.