### PR TITLE
Fixed config override using system properties

### DIFF
--- a/knotx-core/src/main/java/io/knotx/launcher/SystemPropsConfiguration.java
+++ b/knotx-core/src/main/java/io/knotx/launcher/SystemPropsConfiguration.java
@@ -16,6 +16,7 @@
 package io.knotx.launcher;
 
 import com.google.common.collect.Maps;
+import io.knotx.exceptions.ConfigurationException;
 import io.vertx.core.json.JsonObject;
 import io.vertx.core.logging.Logger;
 import io.vertx.core.logging.LoggerFactory;
@@ -69,6 +70,7 @@ public class SystemPropsConfiguration {
    * <li>-Dio.knotx.KnotxServer.splitter=file:/aaa/bb/cc.json - this will merge the given cc.json
    * file from the field specified</li>
    * </ul>
+   *
    * @param descriptor - JsonObject with module descriptor
    * @return JsonObject - updated descriptor
    */
@@ -80,7 +82,13 @@ public class SystemPropsConfiguration {
           JsonObject element = object;
           for (int idx = 0; idx < path.length; idx++) {
             if (idx < path.length - 1) {
-              element = element.getJsonObject(path[idx]);
+              if (element.containsKey(path[idx])) {
+                element = element.getJsonObject(path[idx]);
+              } else {
+                throw new ConfigurationException(
+                    "Wrong config override. There is no matching element " + entry.getKey()
+                        + " in the configuration");
+              }
             } else { //last
               if (entry.getValue().getObject() instanceof JsonObject) {
                 element.getJsonObject(path[idx]).mergeIn((JsonObject) entry.getValue().getObject());

--- a/knotx-core/src/main/java/io/knotx/launcher/SystemPropsConfiguration.java
+++ b/knotx-core/src/main/java/io/knotx/launcher/SystemPropsConfiguration.java
@@ -85,7 +85,7 @@ public class SystemPropsConfiguration {
               if (element.containsKey(path[idx])) {
                 element = element.getJsonObject(path[idx]);
               } else {
-                throw new ConfigurationException(
+                throw new IllegalArgumentException (
                     "Wrong config override. There is no matching element " + entry.getKey()
                         + " in the configuration");
               }


### PR DESCRIPTION
Fix for configuraiton override using system properties. There were an issue, if service config was overriden in starter json, and same service had some property overriden by system property, then system prop value overriden the original service config ignoring config from starter json