### PR TITLE
Fixed an error in logger instantiation in SupportedMethodsAndPathsHandler

### DIFF
--- a/knotx-server/src/main/java/io/knotx/server/SupportedMethodsAndPathsHandler.java
+++ b/knotx-server/src/main/java/io/knotx/server/SupportedMethodsAndPathsHandler.java
@@ -23,8 +23,8 @@ import io.vertx.rxjava.ext.web.RoutingContext;
 
 public class SupportedMethodsAndPathsHandler implements Handler<RoutingContext> {
 
-  private static final Logger LOGGER = LoggerFactory.getLogger(KnotxSplitterHandler.class);
-
+  private static final Logger LOGGER = LoggerFactory
+      .getLogger(SupportedMethodsAndPathsHandler.class);
 
   private KnotxServerConfiguration configuration;
 


### PR DESCRIPTION
I noticed that the logger defined in `SupportedMethodsAndPathsHandler` seemed to be using the wrong class (`KnotxSplitterHandler` as opposed to `SupportedMethodsAndPathsHandler`).

This PR makes the logger use the name of the class in which it's used.

---
I hereby agree to the terms of the Knot.x Contributor License Agreement.