### PR TITLE
Fixed awkward hyphenation in the main header

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![][central-repo img]][central-repo]
 [![][gitter img]][gitter]
 
-# Knot.x is a highly-efficient and scalable integration platform for modern websites.
+# Knot.x is a highly efficient and scalable integration platform for modern websites.
 
 <p align="center">
   <img src="https://github.com/Cognifide/knotx/blob/master/icons/180x180.png?raw=true" alt="Knot.x Logo"/>


### PR DESCRIPTION
There's no need to use a hyphen when an adverb modifies an adjective. Changed _highly-efficient_ to _highly efficient_

---

I hereby agree to the terms of the Knot.x Contributor License Agreement.