### PR TITLE
fix for titles not being interpreted on GitHub

### DIFF
--- a/documentation/src/main/wiki/KnotxModules.md
+++ b/documentation/src/main/wiki/KnotxModules.md
@@ -64,7 +64,7 @@ $ java -Dio.knotx.KnotxServer.options.config.httpPort=2000 -jar knotx-xxxx-fat.j
 ```
 See [[Knot.x Deployments|KnotxDeployment]] for details how to supply your configurations.
 
-##How to create your service ?
+## How to create your service ?
 1. Assuming you're implementing your own Knot.x Verticle (either Knot or any kind of Adapter following the appropriate guides), 
 you need to create module descriptor of your verticle to be available in class path. Simply create JSON file in `src/main/resource` folder on your maven module. 
 E.g.: `src/main/resources/my.custom.Service.json`

--- a/documentation/src/main/wiki/KnotxModules.md
+++ b/documentation/src/main/wiki/KnotxModules.md
@@ -64,7 +64,7 @@ $ java -Dio.knotx.KnotxServer.options.config.httpPort=2000 -jar knotx-xxxx-fat.j
 ```
 See [[Knot.x Deployments|KnotxDeployment]] for details how to supply your configurations.
 
-## How to create your service ?
+## How to create your service?
 1. Assuming you're implementing your own Knot.x Verticle (either Knot or any kind of Adapter following the appropriate guides), 
 you need to create module descriptor of your verticle to be available in class path. Simply create JSON file in `src/main/resource` folder on your maven module. 
 E.g.: `src/main/resources/my.custom.Service.json`

--- a/documentation/src/main/wiki/Splitter.md
+++ b/documentation/src/main/wiki/Splitter.md
@@ -2,7 +2,7 @@
 Fragment Splitter reads [[Knot Context|Knot]] having a HTML Template retrieved from Repository using configured connector, splits it into 
 static and dynamic Fragments, updates Knot Context and returns back to the caller.
 
-##How does it work?
+## How does it work?
 It splits HTML Template using regexp `<script\s+data-knotx-knots\s*=\s*"([A-Za-z0-9-]+)"[^>]*>.+?</script>`.
 All matched `script` tags are converted into Fragments containing list of supported [[Knots|Knot]] 
 declared in `data-knotx-knots` attribute. HTML parts below, above and between matched scripts are 


### PR DESCRIPTION
This is the fix for titles not being shown properly. I.e.:
```
##How to create your service ?
```
at https://github.com/Cognifide/knotx/wiki/KnotxModules

and

```
##How does it work? It splits HTML Template using ...
```
at https://github.com/Cognifide/knotx/wiki/Splitter