### PR TITLE
Fixed timout issues when deploying verticles in Junit Rule

### DIFF
--- a/knotx-junit/src/main/java/io/knotx/junit/rule/TestVertxDeployer.java
+++ b/knotx-junit/src/main/java/io/knotx/junit/rule/TestVertxDeployer.java
@@ -19,7 +19,6 @@ import io.knotx.junit.util.FileReader;
 import io.knotx.launcher.KnotxStarterVerticle;
 import io.vertx.core.DeploymentOptions;
 import io.vertx.core.json.JsonObject;
-import io.vertx.ext.unit.impl.Helper;
 import io.vertx.ext.unit.junit.RunTestOnContext;
 import io.vertx.rxjava.core.Vertx;
 import org.junit.rules.TestRule;
@@ -66,7 +65,7 @@ public class TestVertxDeployer implements TestRule {
         } catch (ExecutionException ignore) {
         } catch (InterruptedException e) {
           Thread.currentThread().interrupt();
-          Helper.uncheckedThrow(e);
+          throw e;
         }
 
         base.evaluate();

--- a/knotx-junit/src/main/java/io/knotx/junit/rule/TestVertxDeployer.java
+++ b/knotx-junit/src/main/java/io/knotx/junit/rule/TestVertxDeployer.java
@@ -17,26 +17,18 @@ package io.knotx.junit.rule;
 
 import io.knotx.junit.util.FileReader;
 import io.knotx.launcher.KnotxStarterVerticle;
-import io.vertx.core.AsyncResult;
 import io.vertx.core.DeploymentOptions;
-import io.vertx.core.Future;
-import io.vertx.core.Handler;
 import io.vertx.core.json.JsonObject;
-import io.vertx.ext.unit.Async;
-import io.vertx.ext.unit.impl.CompletionImpl;
 import io.vertx.ext.unit.impl.Helper;
 import io.vertx.ext.unit.junit.RunTestOnContext;
 import io.vertx.rxjava.core.Vertx;
-
-import java.io.IOException;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeUnit;
-
 import org.junit.rules.TestRule;
 import org.junit.runner.Description;
 import org.junit.runners.model.Statement;
+
+import java.io.IOException;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
 
 public class TestVertxDeployer implements TestRule {
 

--- a/knotx-junit/src/main/java/io/knotx/junit/rule/TestVertxDeployer.java
+++ b/knotx-junit/src/main/java/io/knotx/junit/rule/TestVertxDeployer.java
@@ -49,12 +49,12 @@ public class TestVertxDeployer implements TestRule {
         }
         Vertx vertx = Vertx.newInstance(vertxContext.vertx());
 
-        CompletableFuture<String> toComplete = new CompletableFuture<>();
+        CompletableFuture<Void> toComplete = new CompletableFuture<>();
 
         vertx.deployVerticle(KnotxStarterVerticle.class.getName(),
             new DeploymentOptions().setConfig(readJson(knotxConfig.value())), ar -> {
               if (ar.succeeded()) {
-                toComplete.complete("Success");
+                toComplete.complete(null);
               } else {
                 toComplete.completeExceptionally(ar.cause());
               }


### PR DESCRIPTION
Occasionally, on different machines a junit failed becuase verticle wasn't deployed. Change the TestDeployer implementation to use a CompletableFuture that waits for completion of a deployment.