### PR TITLE
Rrepository response in case of ko

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ List of changes that are finished but not yet released in any final version.
  - [PR-353](https://github.com/Cognifide/knotx/pull/353) - Fix for #351 - Deprecated [`ProxyHelper`](http://vertx.io/docs/apidocs/io/vertx/serviceproxy/ProxyHelper.html) replaced with [`ServiceBinder`](http://vertx.io/docs/apidocs/io/vertx/serviceproxy/ServiceBinder.html)
  - [PR-354](https://github.com/Cognifide/knotx/pull/354) - Improvement - added CSRF protection and ability to configure it on any route.
  - [PR-357](https://github.com/Cognifide/knotx/pull/357) - Fix for #356 - Create AdapterProxies on serviceKnot start instead for each request
+ - [PR-359](https://github.com/Cognifide/knotx/pull/359) - Fix for #355 - Knot.x responses with the response of a repository in case of response with status code different than 200.
 
 ## Version 1.1.2
  - [PR-318](https://github.com/Cognifide/knotx/pull/318) - Knot.x returns exit code `30` in case of missing config

--- a/documentation/src/main/wiki/UpgradeNotes.md
+++ b/documentation/src/main/wiki/UpgradeNotes.md
@@ -13,6 +13,10 @@ The API is changed, so your custom implementations need to adopt to the latest A
 - [PR-349](https://github.com/Cognifide/knotx/pull/349) - You can pass [`Delivery Options`](http://vertx.io/docs/apidocs/io/vertx/core/eventbus/DeliveryOptions.html) to Knot.x Verticles e.g. to manipulate eventbus response timeouts. 
 For more details see documentation sections in [[Server|Server#vertx-event-bus-delivery-options]], [[Action Knot|ActionKnot#vertx-event-bus-delivery-options]] and [[Service Knot|ServiceKnot#vertx-event-bus-delivery-options]].
 - [PR-354](https://github.com/Cognifide/knotx/pull/354) - You can now enable XSRF protection on default or custom flow at any path. See [[Server|Server#how-to-enable-csrf-token-generation-and-validation]] for details.
+ - [PR-359](https://github.com/Cognifide/knotx/pull/359) - From now on Knot.x responses with the response of a repository in case of response with status code different than 200. 
+ You may play with [`displayExceptionDetails`](https://github.com/Cognifide/knotx/wiki/Server#server-options) flag
+ in order to receive errors stack traces.
+
 
 ## Version 1.1.2
 - [PR-335](https://github.com/Cognifide/knotx/pull/335) - Added support for HttpServerOptions on the configuration level.

--- a/knotx-core/src/main/asciidoc/dataobjects.adoc
+++ b/knotx-core/src/main/asciidoc/dataobjects.adoc
@@ -1,5 +1,92 @@
 = Cheatsheets
 
+[[AdapterRequest]]
+== AdapterRequest
+
+
+[cols=">25%,^25%,50%"]
+[frame="topbot"]
+|===
+^|Name | Type ^| Description
+|[[adapterParams]]`adapterParams`|`Json object`|
++++
+Set the request params
++++
+|[[params]]`params`|`Json object`|
++++
+Set the request params
++++
+|[[request]]`request`|`link:dataobjects.html#ClientRequest[ClientRequest]`|
++++
+Set the client request
++++
+|===
+
+[[AdapterResponse]]
+== AdapterResponse
+
+
+[cols=">25%,^25%,50%"]
+[frame="topbot"]
+|===
+^|Name | Type ^| Description
+|[[response]]`response`|`link:dataobjects.html#ClientResponse[ClientResponse]`|-
+|[[signal]]`signal`|`String`|-
+|===
+
+[[ClientRequest]]
+== ClientRequest
+
+
+[cols=">25%,^25%,50%"]
+[frame="topbot"]
+|===
+^|Name | Type ^| Description
+|[[jsonFormAttributes]]`jsonFormAttributes`|`Json object`|-
+|[[jsonHeaders]]`jsonHeaders`|`Json object`|
++++
+Serialization variants of MultiMap fields
++++
+|[[jsonParams]]`jsonParams`|`Json object`|-
+|[[method]]`method`|`link:enums.html#HttpMethod[HttpMethod]`|-
+|[[path]]`path`|`String`|-
+|===
+
+[[ClientResponse]]
+== ClientResponse
+
+
+[cols=">25%,^25%,50%"]
+[frame="topbot"]
+|===
+^|Name | Type ^| Description
+|[[body]]`body`|`Buffer`|-
+|[[jsonHeaders]]`jsonHeaders`|`Json object`|
++++
+Serialization variants of MultiMap fields
++++
+|[[statusCode]]`statusCode`|`Number (int)`|-
+|===
+
+[[Fragment]]
+== Fragment
+
+++++
+ An entity representing a markup slice produced during Template fragmentation. It represents both
+ markup with static and dynamic content.
+++++
+'''
+
+[cols=">25%,^25%,50%"]
+[frame="topbot"]
+|===
+^|Name | Type ^| Description
+|[[raw]]`raw`|`Boolean`|
++++
+
++++
+|===
+
 [[KnotContext]]
 == KnotContext
 

--- a/knotx-mocks/src/main/java/io/knotx/mocks/MockActionAdapterVerticle.java
+++ b/knotx-mocks/src/main/java/io/knotx/mocks/MockActionAdapterVerticle.java
@@ -16,7 +16,7 @@
 package io.knotx.mocks;
 
 
-import io.knotx.mocks.adapter.MockActionAdapterHandler;
+import io.knotx.mocks.handler.MockActionAdapterHandler;
 import io.vertx.core.AbstractVerticle;
 import io.vertx.core.logging.Logger;
 import io.vertx.core.logging.LoggerFactory;

--- a/knotx-mocks/src/main/java/io/knotx/mocks/MockRemoteRepositoryVerticle.java
+++ b/knotx-mocks/src/main/java/io/knotx/mocks/MockRemoteRepositoryVerticle.java
@@ -16,7 +16,7 @@
 package io.knotx.mocks;
 
 
-import io.knotx.mocks.adapter.MockRemoteRepositoryHandler;
+import io.knotx.mocks.handler.MockRemoteRepositoryHandler;
 import io.vertx.core.AbstractVerticle;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;

--- a/knotx-mocks/src/main/java/io/knotx/mocks/MockServiceAdapterVerticle.java
+++ b/knotx-mocks/src/main/java/io/knotx/mocks/MockServiceAdapterVerticle.java
@@ -16,7 +16,7 @@
 package io.knotx.mocks;
 
 
-import io.knotx.mocks.adapter.MockAdapterHandler;
+import io.knotx.mocks.handler.MockAdapterHandler;
 import io.vertx.core.AbstractVerticle;
 import io.vertx.core.logging.Logger;
 import io.vertx.core.logging.LoggerFactory;

--- a/knotx-mocks/src/main/java/io/knotx/mocks/MockServiceVerticle.java
+++ b/knotx-mocks/src/main/java/io/knotx/mocks/MockServiceVerticle.java
@@ -16,7 +16,7 @@
 package io.knotx.mocks;
 
 
-import io.knotx.mocks.adapter.MockServiceHandler;
+import io.knotx.mocks.handler.MockServiceHandler;
 import io.vertx.core.AbstractVerticle;
 import io.vertx.core.Future;
 import io.vertx.core.http.HttpMethod;

--- a/knotx-mocks/src/main/java/io/knotx/mocks/handler/MockActionAdapterHandler.java
+++ b/knotx-mocks/src/main/java/io/knotx/mocks/handler/MockActionAdapterHandler.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.knotx.mocks.adapter;
+package io.knotx.mocks.handler;
 
 import io.knotx.dataobjects.AdapterRequest;
 import io.knotx.dataobjects.AdapterResponse;

--- a/knotx-mocks/src/main/java/io/knotx/mocks/handler/MockAdapterHandler.java
+++ b/knotx-mocks/src/main/java/io/knotx/mocks/handler/MockAdapterHandler.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.knotx.mocks.adapter;
+package io.knotx.mocks.handler;
 
 import io.knotx.dataobjects.AdapterRequest;
 import io.knotx.dataobjects.AdapterResponse;

--- a/knotx-mocks/src/main/java/io/knotx/mocks/handler/MockRemoteRepositoryHandler.java
+++ b/knotx-mocks/src/main/java/io/knotx/mocks/handler/MockRemoteRepositoryHandler.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.knotx.mocks.adapter;
+package io.knotx.mocks.handler;
 
 import com.google.common.collect.Sets;
 import io.netty.handler.codec.http.HttpResponseStatus;
@@ -28,15 +28,14 @@ import io.vertx.core.logging.LoggerFactory;
 import io.vertx.ext.web.RoutingContext;
 import java.util.Optional;
 import java.util.Set;
+import org.apache.commons.lang3.StringUtils;
 import rx.functions.Action0;
 
 public class MockRemoteRepositoryHandler implements Handler<RoutingContext> {
 
   private static final String SEPARATOR = "/";
   private static final Logger LOGGER = LoggerFactory.getLogger(MockRemoteRepositoryHandler.class);
-  private static final Set<String> TEST_FILES_EXTENSIONS =
-      Sets.newHashSet("html", "php", "html", "js", "css", "txt", "text", "json", "xml",
-          "xsm", "xsl", "xsd", "xslt", "dtd", "yml", "svg", "csv", "log", "sgml", "sgm");
+
 
   private final Vertx vertx;
   private final String catalogue;
@@ -51,22 +50,14 @@ public class MockRemoteRepositoryHandler implements Handler<RoutingContext> {
     this.delayPerPath = delayPerPath;
   }
 
-  private static String getFileExtension(String filename) {
-    int li = filename.lastIndexOf('.');
-    if (li != -1 && li != filename.length() - 1) {
-      return filename.substring(li + 1, filename.length());
-    }
-    return null;
-  }
 
   @Override
   public void handle(RoutingContext context) {
     String resourcePath = catalogue + SEPARATOR + getContentPath(context.request().path());
     final Optional<String> contentType = Optional
         .ofNullable(MimeMapping.getMimeTypeForFilename(resourcePath));
-    final String fileExtension = getFileExtension(resourcePath);
-    final boolean isTextFile =
-        fileExtension != null && TEST_FILES_EXTENSIONS.contains(fileExtension);
+
+    RepositoryFileExtension fileExtension = RepositoryFileExtension.fromFilename(resourcePath);
 
     vertx.fileSystem().readFile(resourcePath, ar -> {
       HttpServerResponse response = context.response();
@@ -75,8 +66,8 @@ public class MockRemoteRepositoryHandler implements Handler<RoutingContext> {
             resourcePath);
         Buffer fileContent = ar.result();
         generateResponse(context.request().path(), () -> {
-          setHeaders(response, contentType, isTextFile);
-          response.setStatusCode(HttpResponseStatus.OK.code()).end(fileContent);
+          setHeaders(response, contentType, fileExtension.isTextFile());
+          response.setStatusCode(fileExtension.responseStatus.code()).end(fileContent);
         });
       } else {
         LOGGER.error("Unable to read file.", ar.cause());
@@ -127,6 +118,57 @@ public class MockRemoteRepositoryHandler implements Handler<RoutingContext> {
       return path.replaceFirst("/", "");
     } else {
       return path;
+    }
+  }
+
+  private static final class RepositoryFileExtension {
+
+    private static final Set<String> TEXT_FILES_EXTENSIONS =
+        Sets.newHashSet("html", "php", "html", "js", "css", "txt", "text", "json", "xml",
+            "xsm", "xsl", "xsd", "xslt", "dtd", "yml", "svg", "csv", "log", "sgml", "sgm");
+
+    private final String extensions;
+    private final HttpResponseStatus responseStatus;
+
+    private RepositoryFileExtension(String extensions, HttpResponseStatus responseStatus) {
+      this.extensions = extensions;
+      this.responseStatus = responseStatus;
+    }
+
+    static RepositoryFileExtension fromFilename(String filename) {
+      HttpResponseStatus responseCode = HttpResponseStatus.OK;
+      String ext = StringUtils.substringAfterLast(filename, ".");
+      responseCode = extractStatusCode(filename, responseCode);
+
+      return new RepositoryFileExtension(ext, responseCode);
+    }
+
+    private static HttpResponseStatus extractStatusCode(String filename, HttpResponseStatus responseCode) {
+      final String fileWithoutExt = StringUtils.substringBeforeLast(filename, ".");
+      if (StringUtils.isNotBlank(fileWithoutExt)) {
+        final String statusCodeStr = StringUtils.substringAfterLast(fileWithoutExt, ".");
+        try {
+          final int statusCode = Integer.parseInt(statusCodeStr);
+          responseCode = HttpResponseStatus.valueOf(statusCode);
+        } catch (NumberFormatException e) {
+          responseCode = HttpResponseStatus.OK;
+        }
+      }
+      return responseCode;
+    }
+
+    Optional<String> getExtensions() {
+      return Optional.ofNullable(extensions);
+    }
+
+    public HttpResponseStatus getResponseStatus() {
+      return responseStatus;
+    }
+
+    boolean isTextFile() {
+      return getExtensions()
+          .filter(TEXT_FILES_EXTENSIONS::contains)
+          .isPresent();
     }
   }
 

--- a/knotx-mocks/src/main/java/io/knotx/mocks/handler/MockServiceHandler.java
+++ b/knotx-mocks/src/main/java/io/knotx/mocks/handler/MockServiceHandler.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.knotx.mocks.adapter;
+package io.knotx.mocks.handler;
 
 import io.vertx.core.Handler;
 import io.vertx.core.MultiMap;

--- a/knotx-mocks/src/main/resources/mock/repository/content/remote/error.403.html
+++ b/knotx-mocks/src/main/resources/mock/repository/content/remote/error.403.html
@@ -1,0 +1,18 @@
+<!--
+
+    Copyright (C) 2016 Cognifide Limited
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<h1>Forbidden mock</h1>

--- a/knotx-mocks/src/main/resources/mock/repository/content/remote/error.500.html
+++ b/knotx-mocks/src/main/resources/mock/repository/content/remote/error.500.html
@@ -1,0 +1,18 @@
+<!--
+
+    Copyright (C) 2016 Cognifide Limited
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<h1>Internal Server Error mock</h1>

--- a/knotx-mocks/src/main/resources/mock/repository/content/remote/error.504.html
+++ b/knotx-mocks/src/main/resources/mock/repository/content/remote/error.504.html
@@ -1,0 +1,18 @@
+<!--
+
+    Copyright (C) 2016 Cognifide Limited
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<h1> Gateway Timeout mock</h1>

--- a/knotx-repository-connector/knotx-repository-connector-http/src/main/java/io/knotx/repository/HttpRepositoryConnectorVerticle.java
+++ b/knotx-repository-connector/knotx-repository-connector-http/src/main/java/io/knotx/repository/HttpRepositoryConnectorVerticle.java
@@ -16,7 +16,7 @@
 package io.knotx.repository;
 
 import io.knotx.proxy.RepositoryConnectorProxy;
-import io.knotx.repository.impl.RepositoryConnectorProxyImpl;
+import io.knotx.repository.impl.HttpRepositoryConnectorProxyImpl;
 import io.vertx.core.AbstractVerticle;
 import io.vertx.core.Context;
 import io.vertx.core.Vertx;
@@ -51,7 +51,7 @@ public class HttpRepositoryConnectorVerticle extends AbstractVerticle {
     consumer = serviceBinder
         .setAddress(address)
         .register(RepositoryConnectorProxy.class,
-            new RepositoryConnectorProxyImpl(vertx, config()));
+            new HttpRepositoryConnectorProxyImpl(vertx, config()));
   }
 
   @Override

--- a/knotx-repository-connector/knotx-repository-connector-http/src/main/java/io/knotx/repository/impl/HttpRepositoryConnectorProxyImpl.java
+++ b/knotx-repository-connector/knotx-repository-connector-http/src/main/java/io/knotx/repository/impl/HttpRepositoryConnectorProxyImpl.java
@@ -45,9 +45,9 @@ import java.util.List;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
-public class RepositoryConnectorProxyImpl implements RepositoryConnectorProxy {
+public class HttpRepositoryConnectorProxyImpl implements RepositoryConnectorProxy {
 
-  private static final Logger LOGGER = LoggerFactory.getLogger(RepositoryConnectorProxyImpl.class);
+  private static final Logger LOGGER = LoggerFactory.getLogger(HttpRepositoryConnectorProxyImpl.class);
 
   private static final String ERROR_MESSAGE = "Unable to get template from the repository";
 
@@ -58,7 +58,7 @@ public class RepositoryConnectorProxyImpl implements RepositoryConnectorProxy {
   private final JsonObject customRequestHeader;
 
 
-  public RepositoryConnectorProxyImpl(Vertx vertx, JsonObject configuration) {
+  public HttpRepositoryConnectorProxyImpl(Vertx vertx, JsonObject configuration) {
     clientOptions = configuration.getJsonObject("clientOptions", new JsonObject());
     clientDestination = configuration.getJsonObject("clientDestination");
     customRequestHeader = configuration.getJsonObject("customRequestHeader", new JsonObject());
@@ -158,11 +158,10 @@ public class RepositoryConnectorProxyImpl implements RepositoryConnectorProxy {
           DataObjectsUtil.toString(httpResponse.headers()));
     }
 
-    ClientResponse response = new ClientResponse()
+    return new ClientResponse()
         .setStatusCode(httpResponse.statusCode())
         .setHeaders(httpResponse.headers())
         .setBody(buffer.getDelegate());
-    return response;
 
   }
 

--- a/knotx-server/src/test/java/io/knotx/server/KnotxRepositoryHandlerTest.java
+++ b/knotx-server/src/test/java/io/knotx/server/KnotxRepositoryHandlerTest.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright (C) 2016 Cognifide Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.knotx.server;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyInt;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.knotx.dataobjects.ClientResponse;
+import io.knotx.dataobjects.KnotContext;
+import io.knotx.server.configuration.KnotxServerConfiguration;
+import io.knotx.server.configuration.RepositoryEntry;
+import io.vertx.reactivex.core.MultiMap;
+import io.vertx.reactivex.core.Vertx;
+import io.vertx.reactivex.core.buffer.Buffer;
+import io.vertx.reactivex.core.http.HttpServerResponse;
+import io.vertx.reactivex.ext.web.RoutingContext;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class KnotxRepositoryHandlerTest {
+
+  @Mock
+  private Vertx vertx;
+  @Mock
+  private KnotxServerConfiguration configuration;
+  @Mock
+  private ClientResponse clientResponse;
+  @Mock
+  private RoutingContext routingContext;
+  @Mock
+  private RepositoryEntry repositoryEntry;
+  @Mock
+  private KnotContext knotContext;
+  @Mock
+  private HttpServerResponse httpServerResponse;
+
+  private KnotxRepositoryHandler tested;
+
+  @Before
+  public void setUp() throws Exception {
+    tested = KnotxRepositoryHandler.create(vertx, configuration);
+    when(httpServerResponse.setStatusCode(anyInt())).thenReturn(httpServerResponse);
+  }
+
+  @Test
+  public void handleRepositoryResponse_whenResponseIsSuccessAndShouldBeProcessed_expectContextContinuation() {
+    when(clientResponse.getStatusCode()).thenReturn(200);
+    when(repositoryEntry.doProcessing()).thenReturn(true);
+
+    tested.handleRepositoryResponse(clientResponse, routingContext, repositoryEntry, knotContext);
+
+    verify(knotContext, times(1)).setClientResponse(clientResponse);
+    verify(routingContext, times(1)).put(KnotContext.KEY, knotContext);
+    verify(routingContext, times(1)).next();
+  }
+
+  @Test
+  public void handleRepositoryResponse_whenResponseIsSuccessAndShouldNotBeProcessed_expectResponse() {
+    when(clientResponse.getStatusCode()).thenReturn(200);
+    when(repositoryEntry.doProcessing()).thenReturn(false);
+    when(clientResponse.getHeaders()).thenReturn(MultiMap.caseInsensitiveMultiMap());
+    when(clientResponse.getBody()).thenReturn(Buffer.buffer().getDelegate());
+    when(routingContext.response()).thenReturn(httpServerResponse);
+
+
+    tested.handleRepositoryResponse(clientResponse, routingContext, repositoryEntry, knotContext);
+
+    verify(routingContext, times(0)).next();
+    verify(httpServerResponse, times(1)).setStatusCode(200);
+    verify(httpServerResponse, times(1)).end(any(Buffer.class));
+  }
+
+  @Test
+  public void handleRepositoryResponse_whenResponseIsError_expectErrorResponse() {
+    when(clientResponse.getStatusCode()).thenReturn(400);
+    when(clientResponse.getHeaders()).thenReturn(MultiMap.caseInsensitiveMultiMap());
+    when(clientResponse.getBody()).thenReturn(Buffer.buffer().getDelegate());
+    when(routingContext.response()).thenReturn(httpServerResponse);
+
+
+    tested.handleRepositoryResponse(clientResponse, routingContext, repositoryEntry, knotContext);
+
+    verify(routingContext, times(0)).next();
+    verify(httpServerResponse, times(1)).setStatusCode(400);
+    verify(httpServerResponse, times(1)).end(any(Buffer.class));
+  }
+}


### PR DESCRIPTION
Knot.x responses with the response of a repository in case of response with status code different than `200`.
Additionally Remote Repository Mock can now return error responses (e.g. http://localhost:3001/content/remote/error.403.html will return `403` response).

---

I hereby agree to the terms of the Knot.x Contributor License Agreement.