### PR TITLE
Enable keepAlive connection in http client options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ List of changes that are finished but not yet released in any final version.
  - [PR-369](https://github.com/Cognifide/knotx/pull/369) - Better support for SSL for Repository Connector
  - [PR-371](https://github.com/Cognifide/knotx/pull/371) - Fixed debug logging of HTTP Repository Connector
  - [PR-372](https://github.com/Cognifide/knotx/pull/372) - Added cache for compiled Handlebars snippets
+ - [PR-374](https://github.com/Cognifide/knotx/pull/374) - Enable keepAlive connection in http client options
 
 ## Version 1.1.2
  - [PR-318](https://github.com/Cognifide/knotx/pull/318) - Knot.x returns exit code `30` in case of missing config

--- a/documentation/src/main/wiki/HttpRepositoryConnector.md
+++ b/documentation/src/main/wiki/HttpRepositoryConnector.md
@@ -20,7 +20,7 @@ Default configuration shipped with the verticle as `io.knotx.HttpRepositoryConne
       "address": "knotx.core.repository.http",
       "clientOptions": {
         "maxPoolSize": 1000,
-        "keepAlive": false,
+        "setIdleTimeout": 600,
         "tryUseCompression": true
       },
       "clientDestination": {

--- a/documentation/src/main/wiki/HttpServiceAdapter.md
+++ b/documentation/src/main/wiki/HttpServiceAdapter.md
@@ -60,7 +60,8 @@ Default configuration shipped with the verticle as `io.knotx.HttpServiceAdapter.
       "address": "knotx.adapter.service.http",
       "clientOptions": {
         "maxPoolSize": 1000,
-        "keepAlive": false,
+        "setIdleTimeout": 600,
+        "tryUseCompression": true,
         "logActivity": true
       },
       "customRequestHeader": {
@@ -98,7 +99,8 @@ will be processed by Http Service Adapter.
 - `clientOptions` are [HttpClientOptions](http://vertx.io/docs/apidocs/io/vertx/core/http/HttpClientOptions.html) used to configure HTTP connection.
 Any HttpClientOption may be defined in this section, at this example two options are defined:
   - `maxPoolSize` -  maximum pool size for simultaneous connections,
-  - `keepAlive` - that shows keep alive should be disabled on the client.
+  - `setIdleTimeout` - any connections not used within this timeout will be closed, set in seconds,
+  - `keepAlive` - that shows keep alive, we recommend to leave it set to `true` as the default value in Vert.x. You can find more information [here](http://vertx.io/docs/vertx-core/java/#_http_1_x_pooling_and_keep_alive).
 - `customRequestHeader` - an JSON object that consists of name and value of the header to be sent in each request to any service configured. If the same header comes from the client request, it will be always overwritten with the value configured here.
 - `services` - an JSON array of services that Http Service Adapter can connect to. Each service is distinguished by `path` parameter which is regex.
 In example above, two services are configured:

--- a/documentation/src/main/wiki/UpgradeNotes.md
+++ b/documentation/src/main/wiki/UpgradeNotes.md
@@ -18,7 +18,7 @@ For more details see documentation sections in [[Server|Server#vertx-event-bus-d
  in order to receive errors stack traces.
 - [PR-369](https://github.com/Cognifide/knotx/pull/369) - Better support for SSL for Repository Connector. Please check the documentation of [[HttpRepositoryConnector|HttpRepositoryConnector#how-to-configure-ssl-connection-to-the-repository]] for details of how to setup SSL connection.
 - [PR-372](https://github.com/Cognifide/knotx/pull/372) - Added cache for compiled Handlebars snippets, you may configure it in Handlebars config, see more in [[Handlebars Knot docs|HandlebarsKnot#how-to-configure]].
-
+ - [PR-374](https://github.com/Cognifide/knotx/pull/374) - Enable keepAlive connection in http client options. This is important fix and we recommend to update your existing configuration of any http client and enable `keepAlive` option.
 
 ## Version 1.1.2
 - [PR-335](https://github.com/Cognifide/knotx/pull/335) - Added support for HttpServerOptions on the configuration level.

--- a/knotx-adapter/knotx-adapter-service-http/src/main/resources/io.knotx.HttpServiceAdapter.json
+++ b/knotx-adapter/knotx-adapter-service-http/src/main/resources/io.knotx.HttpServiceAdapter.json
@@ -5,7 +5,8 @@
       "address": "knotx.adapter.service.http",
       "clientOptions": {
         "maxPoolSize": 1000,
-        "keepAlive": false,
+        "setIdleTimeout": 600,
+        "tryUseCompression": true,
         "logActivity": false
       },
       "customRequestHeader": {

--- a/knotx-adapter/knotx-adapter-service-http/src/test/resources/test.io.knotx.HttpServiceAdapter.json
+++ b/knotx-adapter/knotx-adapter-service-http/src/test/resources/test.io.knotx.HttpServiceAdapter.json
@@ -5,7 +5,8 @@
       "address": "knotx.adapter.service.http",
       "clientOptions": {
         "maxPoolSize": 1000,
-        "keepAlive": false
+        "setIdleTimeout": 600,
+        "tryUseCompression": true
       },
       "services": [
         {

--- a/knotx-example/knotx-example-action-adapter-http/src/main/resources/example.io.knotx.HttpActionAdapter.json
+++ b/knotx-example/knotx-example-action-adapter-http/src/main/resources/example.io.knotx.HttpActionAdapter.json
@@ -5,7 +5,8 @@
       "address": "knotx.adapter.action.http",
       "clientOptions": {
         "maxPoolSize": 1000,
-        "keepAlive": false
+        "setIdleTimeout": 600,
+        "tryUseCompression": true
       },
       "customRequestHeader": {
         "name": "Server-User-Agent",

--- a/knotx-example/knotx-example-action-adapter-http/src/test/resources/test.io.knotx.HttpActionAdapter.json
+++ b/knotx-example/knotx-example-action-adapter-http/src/test/resources/test.io.knotx.HttpActionAdapter.json
@@ -5,7 +5,8 @@
       "address": "knotx.adapter.action.http",
       "clientOptions": {
         "maxPoolSize": 1000,
-        "keepAlive": false
+        "setIdleTimeout": 600,
+        "tryUseCompression": true
       },
       "services": [
         {

--- a/knotx-example/knotx-example-app/src/test/resources/example.io.knotx.HttpActionAdapter.json
+++ b/knotx-example/knotx-example-app/src/test/resources/example.io.knotx.HttpActionAdapter.json
@@ -5,7 +5,8 @@
       "address": "knotx.adapter.action.http",
       "clientOptions": {
         "maxPoolSize": 1000,
-        "keepAlive": false
+        "setIdleTimeout": 600,
+        "tryUseCompression": true
       },
       "services": [
         {

--- a/knotx-example/knotx-example-app/src/test/resources/io.knotx.HttpActionAdapter.json
+++ b/knotx-example/knotx-example-app/src/test/resources/io.knotx.HttpActionAdapter.json
@@ -5,7 +5,8 @@
       "address": "knotx.adapter.action.http",
       "clientOptions": {
         "maxPoolSize": 1000,
-        "keepAlive": false
+        "setIdleTimeout": 600,
+        "tryUseCompression": true
       },
       "services": [
         {

--- a/knotx-example/knotx-example-app/src/test/resources/io.knotx.HttpRepositoryConnector.json
+++ b/knotx-example/knotx-example-app/src/test/resources/io.knotx.HttpRepositoryConnector.json
@@ -5,7 +5,7 @@
       "address": "knotx.core.repository.http",
       "clientOptions": {
         "maxPoolSize": 1000,
-        "keepAlive": false,
+        "setIdleTimeout": 600,
         "tryUseCompression": true
       },
       "clientDestination": {

--- a/knotx-example/knotx-example-app/src/test/resources/io.knotx.HttpServiceAdapter.json
+++ b/knotx-example/knotx-example-app/src/test/resources/io.knotx.HttpServiceAdapter.json
@@ -5,7 +5,8 @@
       "address": "knotx.adapter.service.http",
       "clientOptions": {
         "maxPoolSize": 1000,
-        "keepAlive": false,
+        "setIdleTimeout": 600,
+        "tryUseCompression": true,
         "logActivity": true
       },
       "services": [

--- a/knotx-knot/knotx-knot-service/src/test/resources/template-engine/test-config.json
+++ b/knotx-knot/knotx-knot-service/src/test/resources/template-engine/test-config.json
@@ -2,7 +2,8 @@
   "address": "knotx.knot.service",
   "clientOptions": {
     "maxPoolSize": 100,
-    "keepAlive": false
+    "setIdleTimeout": 600,
+    "tryUseCompression": true
   },
   "services": [
     {

--- a/knotx-repository-connector/knotx-repository-connector-http/src/main/resources/io.knotx.HttpRepositoryConnector.json
+++ b/knotx-repository-connector/knotx-repository-connector-http/src/main/resources/io.knotx.HttpRepositoryConnector.json
@@ -5,7 +5,7 @@
       "address": "knotx.core.repository.http",
       "clientOptions": {
         "maxPoolSize": 1000,
-        "keepAlive": false,
+        "setIdleTimeout": 600,
         "tryUseCompression": true
       },
       "clientDestination": {


### PR DESCRIPTION
## Description
Enable keepAlive connection in http client options.
Until now we had small bug in configuration and `keepAlive` disabled.
Additionally I've added `setIdleTimeout` that will close any connections not used within this timeout.

## Motivation and Context
Performance improvement.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


---
I hereby agree to the terms of the Knot.x Contributor License Agreement.
