### PR TITLE
Feature/378 request logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ List of changes that are finished but not yet released in any final version.
  - [PR-371](https://github.com/Cognifide/knotx/pull/371) - Fixed debug logging of HTTP Repository Connector
  - [PR-372](https://github.com/Cognifide/knotx/pull/372) - Added cache for compiled Handlebars snippets
  - [PR-374](https://github.com/Cognifide/knotx/pull/374) - Enable keepAlive connection in http client options
- - [PR-379](https://github.com/Cognifide/knotx/pull/379) - Added access logging capabilities to the Knotx HTTP Server
+ - [PR-379](https://github.com/Cognifide/knotx/pull/379) - Added access logging capabilities to the Knotx HTTP Server. Establish standard configuration of logback logger.
 
 ## Version 1.1.2
  - [PR-318](https://github.com/Cognifide/knotx/pull/318) - Knot.x returns exit code `30` in case of missing config

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ List of changes that are finished but not yet released in any final version.
  - [PR-371](https://github.com/Cognifide/knotx/pull/371) - Fixed debug logging of HTTP Repository Connector
  - [PR-372](https://github.com/Cognifide/knotx/pull/372) - Added cache for compiled Handlebars snippets
  - [PR-374](https://github.com/Cognifide/knotx/pull/374) - Enable keepAlive connection in http client options
+ - [PR-379](https://github.com/Cognifide/knotx/pull/379) - Added access logging capabilities to the Knotx HTTP Server
 
 ## Version 1.1.2
  - [PR-318](https://github.com/Cognifide/knotx/pull/318) - Knot.x returns exit code `30` in case of missing config

--- a/documentation/src/main/DocumentationTemplate.md
+++ b/documentation/src/main/DocumentationTemplate.md
@@ -26,6 +26,7 @@
 #include "wiki/Mocks.md"
 #include "wiki/KnotxDeployment.md"
 #include "wiki/KnotxTuning.md"
+#include "wiki/Logging.md"
 #include "wiki/Dependencies.md"
 #include "wiki/FAQ.md"
 #include "wiki/UpgradeNotes.md"

--- a/documentation/src/main/wiki/Home.md
+++ b/documentation/src/main/wiki/Home.md
@@ -31,6 +31,7 @@ User documentation is available at [http://knotx.io](http://knotx.io/).
 * [[Mocks|Mocks]]
 * [[Knot.x Deployment|KnotxDeployment]]
   * [[Knot.x Tuning|KnotxTuning]]
+* [[Logging|Logging]]
 * [[Performance|PerformanceTests]]
   * [[Performance Tests Methodology|PerformanceTestsMethodology]]
   * [[Performance Tests Summary|PerformanceTestsSummary]]

--- a/documentation/src/main/wiki/Logging.md
+++ b/documentation/src/main/wiki/Logging.md
@@ -1,0 +1,51 @@
+# Logging
+By default Knot.x picks up the logger configuration from its default location for the system (e.g. classpath:logback.xml), but you can set the location of the config file through `logback.configurationFile` system property.
+```
+java -Dlogback.configurationFile=/path/to/logback.xml -jar ...
+```
+- ### TBD: what types of logs availble (knotx, access, netty)
+- ### TBD: how it logs by default
+
+## Configure Logback
+Knot.x provides a default base configuration that you can include if you just want to set levels, e.g.
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration scan="true">
+    <include resource="io/knotx/logging/logback/base.xml"/>
+    <logger name="io.knotx" level="TRACE"/>
+</configuration>
+```
+The `base.xml` file uses useful System properties which the Logback takes care of creating for you. These are:
+- `${LOG_PATH}` - represents a directory for log files to live in).
+- #### TBD ######
+
+See the [default `base.xml`](https://github.com/Cognifide/knotx/blob/master/knotx-core/src/main/resources/io/knotx/logging/logback/base.xml) configuration for details.
+
+## Configure logback for file only output
+If you want to disable console logging and write output only to a file you need a custom logback.xml that imports file-appender.xml but not console-appender.xml:
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <include resource="io/knotx/logging/logback/defaults.xml" />
+    <include resource="io/knotx/logging/logback/file-appender.xml" />
+    <root level="INFO">
+        <appender-ref ref="FILE" />
+    </root>
+</configuration>
+```
+
+You also need to set `LOG_PATH` System property to point one where the file will be logged. As an alternative you can set that property inside your logback.xml
+```xml
+<configuration>
+  <property name="LOG_PATH" value="/path/to/logs"/>
+  <include resource="io/knotx/logging/logback/defaults.xml" />
+  ...
+</configuration>
+```
+
+## Configure logback to log into multiple files
+
+## Extras
+Logback logger brings a tremendous amount of possibilities how to store your logs. It's impossible to present here all possibilities, so the best way would be a [Logback Documentation](https://logback.qos.ch/manual/index.html). 

--- a/documentation/src/main/wiki/Logging.md
+++ b/documentation/src/main/wiki/Logging.md
@@ -1,51 +1,178 @@
 # Logging
-By default Knot.x picks up the logger configuration from its default location for the system (e.g. classpath:logback.xml), but you can set the location of the config file through `logback.configurationFile` system property.
+By default Knot.x picks up the logger configuration from its default location for the system (e.g. classpath:logback.xml), 
+but you can set the location of the config file through `logback.configurationFile` system property.
 ```
 java -Dlogback.configurationFile=/path/to/logback.xml -jar ...
 ```
-- ### TBD: what types of logs availble (knotx, access, netty)
-- ### TBD: how it logs by default
+Knot.x core provides preconfigured three log files:
+- `knotx.log` that logs all **ERROR** messages from the Netty & Vert.x and **INFO** messages from Knot.x application. Enabled by default on Knot.x standalone
+- `knotx-access.log` that logs all HTTP requests/responses to the Knot.x HTTP Server. Enabled by default on Knot.x standalone
+- `knotx-netty.log` that logs all network activity (logged by the Netty). Not enabled on Knot.x standalone. See [[Log network activity|#log-network-activity]] on how to enable it.
+
+All logs are configured by default:
+- To log both to file and console
+- Log files are rolled over every day or if the log file exceeds 10MB
+- Rolled files are automatically compressed
+- History log files are kept forever
+
+A default configuration can be overriden in order to meet your log policy. See [[Configure logback|#configure-logback]] for details.
 
 ## Configure Logback
-Knot.x provides a default base configuration that you can include if you just want to set levels, e.g.
+Knot.x provides a default set of logback configurations that you can include, if you just want to set levels, or create your own specific loggers, e.g.
 
 ```xml
 <?xml version="1.0" encoding="UTF-8"?>
 <configuration scan="true">
-    <include resource="io/knotx/logging/logback/base.xml"/>
-    <logger name="io.knotx" level="TRACE"/>
+  <include resource="io/knotx/logging/logback/defaults.xml"/>
+  <include resource="io/knotx/logging/logback/console-appender.xml"/>
+  <include resource="io/knotx/logging/logback/file-appender.xml"/>
+
+  <root level="INFO">
+    <appender-ref ref="CONSOLE"/>
+    <appender-ref ref="FILE"/>
+  </root>
+
+  <logger name="io.knotx" level="TRACE"/>
 </configuration>
 ```
-The `base.xml` file uses useful System properties which the Logback takes care of creating for you. These are:
-- `${LOG_PATH}` - represents a directory for log files to live in).
-- #### TBD ######
+Will create console & file logger for Knot.x logs. Besides that there are other includes that brings new logs, these are:
+- `io/knotx/logging/logback/access.xml` - access log
+- `io/knotx/logging/logback/netty.xml` - network activity logs
 
-See the [default `base.xml`](https://github.com/Cognifide/knotx/blob/master/knotx-core/src/main/resources/io/knotx/logging/logback/base.xml) configuration for details.
+All those configurations uses useful System properties which the Logback takes care of creating for you. These are:
+- `${LOG_PATH}` - represents a directory for log files to live in, for knotx, access & netty logs. It's set with the value from `LOG_PATH` System property, or from your own logback.xml file. If none of these specified, logs to the current working directory `/logs` subfolder.
+- `${KNOTX_LOG_FILE}`, `${ACCESS_LOG_FILE}`, `${NETTY_LOG_FILE}` - Ignores `LOG_PATH` and use that property to specify actual location for the knotx, access & netty log files (e.g. `/var/logs/knotx.log`, or `/var/logs/access.log`)
+- `${KNOTX_LOG_DATEFORMAT_PATTERN}` - Allows to specify a different date-time format for log entries in `knotx.log` and `knotx-netty.log` files only. If not specified, `yyyy-MM-dd HH:mm:ss.SSS` is used.
+- `${CONSOLE_KNOTX_LOG_PATTERN}` - Allows to override a default log pattern for console logging.
+- `${FILE_KNOTX_LOG_PATTERN}`, `${FILE_ACCESS_LOG_PATTERN}`, `${FILE_NETTY_LOG_PATTERN}` - Allows to override a default log pattern for knotx, access & netty logs.
+- `${KNOTX_LOG_FILE_MAX_SIZE}`, `${ACCESS_LOG_FILE_MAX_SIZE}`, `${NETTY_LOG_FILE_MAX_SIZE}` - Allows to define a maximum size of knotx, access & netty log files. If not specified, a max size is `10MB`
+- `${KNOTX_LOG_FILE_MAX_HISTORY}`, `${ACCESS_LOG_FILE_MAX_HISTORY}`, `${NETTY_LOG_FILE_MAX_HISTORY}` - Allows to define a maximum amount of archived log files kept in the log folder (for knotx, access & netty logs). If not specified, it keeps files forever.
+
+See the [Knot.x core logback settings](https://github.com/Cognifide/knotx/blob/master/knotx-core/src/main/resources/io/knotx/logging/logback/) configuration files for details.
 
 ## Configure logback for file only output
-If you want to disable console logging and write output only to a file you need a custom logback.xml that imports file-appender.xml but not console-appender.xml:
+In a production system, you want to disable console logging and write output only to a file both for knotx & access logs. 
+You need to create a custom `logback.xml` that imports `file-appender.xml` but not `console-appender.xml`:
 
 ```xml
 <?xml version="1.0" encoding="UTF-8"?>
 <configuration>
     <include resource="io/knotx/logging/logback/defaults.xml" />
     <include resource="io/knotx/logging/logback/file-appender.xml" />
+    <include resource="io/knotx/logging/logback/access.xml" />
+    
     <root level="INFO">
         <appender-ref ref="FILE" />
     </root>
 </configuration>
 ```
 
-You also need to set `LOG_PATH` System property to point one where the file will be logged. As an alternative you can set that property inside your logback.xml
+**NOTE: Do not forgot to specify usage of your custom logback file through `-Dlogback.configurationFile` system property.**
+
+Additionally, you want to specify a location of log files in your file system. And roll over policy to keep last 30 archived log files.
+You can do this, through your custom logback file:
 ```xml
 <configuration>
   <property name="LOG_PATH" value="/path/to/logs"/>
+  <property name="KNOTX_LOG_FILE_MAX_HISTORY" value="30"/>
+  <property name="ACCESS_LOG_FILE_MAX_HISTORY" value="30"/>
+  
   <include resource="io/knotx/logging/logback/defaults.xml" />
   ...
 </configuration>
 ```
+Or, you can provide those settings through System properties:
+```
+-DLOG_PATH=/path/to/logs -DKNOTX_LOG_FILE_MAX_HISTORY=30 -DACCESS_LOG_FILE_MAX_HISTORY=30
+```
+Or, even you can mix both approaches. So define default settings inside logback, and configure to respect new System properties you can use to override
+```xml
+<configuration>
+  <property name="LOG_PATH" value="${my.logs:-/path/to/logs}"/>
+  <property name="KNOTX_LOG_FILE_MAX_HISTORY" value="${my.logs.history:-30}"/>
+  <property name="ACCESS_LOG_FILE_MAX_HISTORY" value="${my.logs.history:-30}"/>
+  
+  <include resource="io/knotx/logging/logback/defaults.xml" />
+  ...
+</configuration>
+```
+And your System property, that will set different log path, and max history for both log files to `100`:
+```
+-Dmy.logs=/other/path -Dmy.logs.history=100
+```
+As you can see, Logback logger brings a tremendous amount of possibilities how to configure your logs. 
+It's impossible to present here all the possibilities, so the best way would be to study [Logback Documentation](https://logback.qos.ch/manual/index.html). 
 
-## Configure logback to log into multiple files
+## Log network activity
+Network activity (logged by Netty) logger settings are provided by the Knot.x core. In order to log it, you need to use your custom logback.xml file and configure it as follows
+```xml
+<configuration>
+    <!-- Your properties is required -->
+    
+    <!-- Knotx & access logs -->
+    <include resource="io/knotx/logging/logback/defaults.xml" />
+    <include resource="io/knotx/logging/logback/file-appender.xml" />
+    <include resource="io/knotx/logging/logback/access.xml" />
+ 
+    <!-- Add netty network activity logger -->
+    <include resource="io/knotx/logging/logback/netty.xml" />
+    
+    <!-- other logger settings -->
+</configuration>
+```
+Additionally, in your knot.x json configuration file, you need to enable logging network activity. You can enable this both for HTTP server as well as HTTP clients used.
+- To enable it for server, just overwrite KnotxServer configuration:
+```json
+"config": {
+   "serverOptions": {
+      "logActivity": true
+   }
+}
+```
+- To enable it for HTTP Clients, just overwrite any or all service adapter configurations:
+```json
+"config": {
+   "clientOptions": {
+      "logActivity": true
+   }
+}
+```
 
-## Extras
-Logback logger brings a tremendous amount of possibilities how to store your logs. It's impossible to present here all possibilities, so the best way would be a [Logback Documentation](https://logback.qos.ch/manual/index.html). 
+## Configure logback to log my specific package
+If you added your own Knot's, Adapters or any other extension to the Knot.x you want to have this information to be logged in your log files.
+```xml
+<configuration>
+    <!-- Your properties is required -->
+    
+    <!-- Knotx & access logs -->
+    <include resource="io/knotx/logging/logback/defaults.xml" />
+    <include resource="io/knotx/logging/logback/file-appender.xml" />
+    <include resource="io/knotx/logging/logback/access.xml" />
+    
+    <!-- other logger settings -->
+    
+    <!-- project specific logger -->
+    <logger name="com.example.extension" level="INFO">
+      <appender-ref ref="FILE" />
+    </logger>
+</configuration>
+```
+- Add `logger` for your package or class, define a level of logs
+- Specify `FILE` appender as a logs target.
+Your logs will appear in the `knotx.log`
+
+However, you might wanted to log your package logs into a separate file, to not polute `knotx.log`.
+- create your own file appender (see `io/knotx/logging/logback/file-appender.xml` as an example) with the name e.g. `MY_FILE`
+- bind your logger to `MY_FILE` appender
+- set logger to `additivity="false"`, so your logs will go just to your new file. If specified to `true` logs will go to the parent logger into `knotx.log` files too.
+
+```xml
+<appender name="MY_FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+  <!-- Appender settings -->
+</appender>
+
+<!-- project specific logger -->
+<logger name="com.example.extension" level="INFO" additivity="false">
+  <appender-ref ref="MY_FILE" />
+</logger>
+```

--- a/documentation/src/main/wiki/Server.md
+++ b/documentation/src/main/wiki/Server.md
@@ -359,7 +359,7 @@ for eventubs requests that come from `KnotxServer`.
 ### Configure access log
 Knot.x uses a default Logging handler from the Vert.x web distribution that allows to log all incomming requests to the Http server.
 It supports three log line formats that are:
-- DEFAULT that tries to log in a format similar to Apache log format (APACHE/NCSA COMBINED LOG FORMAT)
+- DEFAULT that tries to log in a format similar to Apache log format (APACHE/NCSA COMBINED LOG FORMAT) as in the example
 `127.0.0.1 - - [Tue, 23 Jan 2018 14:16:34 GMT] "GET /content/local/simple.html HTTP/1.1" 200 2963 "-" "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/63.0.3239.132 Safari/537.36"`
 - SHORT
 `127.0.0.1 - GET /content/local/simple.html HTTP/1.1 200 2963 - 19 ms`
@@ -382,23 +382,4 @@ By default access log is enabled with a `DEFAULT` format. If you want to change 
   }
 }
 ```
-In order to log the access log to a separate file, just configure your logger in `logback.xml` file as follows
-```xml
-  <appender name="access" class="ch.qos.logback.core.FileAppender">
-    <file>access.log</file>
-    <append>true</append>
-    <!-- set immediateFlush to false for much higher logging throughput -->
-    <immediateFlush>true</immediateFlush>
-    <encoder>
-      <pattern>%msg%n</pattern>
-    </encoder>
-  </appender>
-
-  <logger name="io.vertx.ext.web.handler.impl.LoggerHandlerImpl" level="INFO" additivity="false">
-    <appender-ref ref="access"/>
-  </logger>
-```
-This configures log appender as file, with the pattern being just a message.
-Next step, is to add logger for `io.vertx.ext.web.handler.impl.LoggerHandlerImpl` to be flushed out into your new appender.
-
-See [logback.xml](https://github.com/Cognifide/knotx/blob/master/knotx-example/knotx-example-app/src/main/resources/logback.xml) from the example app as an example.
+In order to configure logger for access log, see [[Logging|Logging]].

--- a/documentation/src/main/wiki/Server.md
+++ b/documentation/src/main/wiki/Server.md
@@ -221,7 +221,7 @@ The `repositories`, `splitter` and `assembler` verticles are specific to the def
 |-------:|:-------:|:-------:  |-------|
 | `enabled`   | `boolean` |       | Enable/Disable access log. Default is `true` |
 | `immediate` | `boolean` |       | Log before request or after. Default is `false` - log after request |
-| `format`    | `String` |        | Format of the access log. Allowed valueds are `DEFAULT`, `SHORT`, `TINY`. Default tries to log in a format similar to Apache log format, while the other 2 are more suited to development mode. Default format is `DEFAULT` |
+| `format`    | `String` |        | Format of the access log. Allowed valueds are `DEFAULT`, `SHORT`, `TINY`. See [[Configure Access Log|#configure-access-log]]. Default format is `DEFAULT` |
 
 
 ### Vert.x HTTP Server configurations
@@ -359,7 +359,7 @@ for eventubs requests that come from `KnotxServer`.
 ### Configure access log
 Knot.x uses a default Logging handler from the Vert.x web distribution that allows to log all incomming requests to the Http server.
 It supports three log line formats that are:
-- DEFAULT that tries to log in a format similar to Apache log format
+- DEFAULT that tries to log in a format similar to Apache log format (APACHE/NCSA COMBINED LOG FORMAT)
 `127.0.0.1 - - [Tue, 23 Jan 2018 14:16:34 GMT] "GET /content/local/simple.html HTTP/1.1" 200 2963 "-" "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/63.0.3239.132 Safari/537.36"`
 - SHORT
 `127.0.0.1 - GET /content/local/simple.html HTTP/1.1 200 2963 - 19 ms`

--- a/documentation/src/main/wiki/Server.md
+++ b/documentation/src/main/wiki/Server.md
@@ -159,6 +159,7 @@ Main server options available.
 | `csrf`                      | `KnotxCSRFConfiguration`            |                | Configuration of the CSRF tokens |
 | `defaultFlow`               | `KnotxFlowConfiguration`            | &#10004;       | Configuration of [[default Knot.X routing|KnotRouting]] |
 | `customFlow`                | `KnotxFlowConfiguration`            |                | Configuration of [[Gateway Mode|GatewayMode]] |
+| `accessLog`                 | `AccessLogConfiguration`            |                | Configuration of the KnotxServer access log |
 
 ### KnotxServerCustomHeader options
  Name  | Type  | Mandatory | Description  |
@@ -213,6 +214,15 @@ The `repositories`, `splitter` and `assembler` verticles are specific to the def
 |-------:|:-------:|:-------:  |-------|
 | `address`      | `String`         | &#10004;       | Event bus address of the **Knot** verticle |
 | `onTransition` | `KnotRouteEntry` |        | Describes routing to addresses of other Knots based on the transition trigger returned from current Knot.<br/>`"onTransition": { "go-d": {}, "go-e": {} }` |
+
+
+### AccessLogConfiguration options
+| Name  | Type  | Mandatory | Description  |
+|-------:|:-------:|:-------:  |-------|
+| `enabled`   | `boolean` |       | Enable/Disable access log. Default is `true` |
+| `immediate` | `boolean` |       | Log before request or after. Default is `false` - log after request |
+| `format`    | `String` |        | Format of the access log. Allowed valueds are `DEFAULT`, `SHORT`, `TINY`. Default tries to log in a format similar to Apache log format, while the other 2 are more suited to development mode. Default format is `DEFAULT` |
+
 
 ### Vert.x HTTP Server configurations
 
@@ -345,3 +355,50 @@ for eventubs requests that come from `KnotxServer`.
   }
 }
 ```
+
+### Configure access log
+Knot.x uses a default Logging handler from the Vert.x web distribution that allows to log all incomming requests to the Http server.
+It supports three log line formats that are:
+- DEFAULT that tries to log in a format similar to Apache log format
+`127.0.0.1 - - [Tue, 23 Jan 2018 14:16:34 GMT] "GET /content/local/simple.html HTTP/1.1" 200 2963 "-" "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/63.0.3239.132 Safari/537.36"`
+- SHORT
+`127.0.0.1 - GET /content/local/simple.html HTTP/1.1 200 2963 - 19 ms`
+- TINY
+`GET /content/local/simple.html 200 2963 - 24 ms`
+
+By default access log is enabled with a `DEFAULT` format. If you want to change it, just add access logging section on the KnotxServer configuration in your application.json config file :
+```json
+{
+  "config": {
+    "knotx:io.knotx.KnotxServer": {
+      "options": {
+        "config": {
+          "accessLog": {
+            "format": "TINY"
+          }
+        }
+      }
+    }
+  }
+}
+```
+In order to log the access log to a separate file, just configure your logger in `logback.xml` file as follows
+```xml
+  <appender name="access" class="ch.qos.logback.core.FileAppender">
+    <file>access.log</file>
+    <append>true</append>
+    <!-- set immediateFlush to false for much higher logging throughput -->
+    <immediateFlush>true</immediateFlush>
+    <encoder>
+      <pattern>%msg%n</pattern>
+    </encoder>
+  </appender>
+
+  <logger name="io.vertx.ext.web.handler.impl.LoggerHandlerImpl" level="INFO" additivity="false">
+    <appender-ref ref="access"/>
+  </logger>
+```
+This configures log appender as file, with the pattern being just a message.
+Next step, is to add logger for `io.vertx.ext.web.handler.impl.LoggerHandlerImpl` to be flushed out into your new appender.
+
+See [logback.xml](https://github.com/Cognifide/knotx/blob/master/knotx-example/knotx-example-app/src/main/resources/logback.xml) from the example app as an example.

--- a/documentation/src/main/wiki/UpgradeNotes.md
+++ b/documentation/src/main/wiki/UpgradeNotes.md
@@ -18,7 +18,9 @@ For more details see documentation sections in [[Server|Server#vertx-event-bus-d
  in order to receive errors stack traces.
 - [PR-369](https://github.com/Cognifide/knotx/pull/369) - Better support for SSL for Repository Connector. Please check the documentation of [[HttpRepositoryConnector|HttpRepositoryConnector#how-to-configure-ssl-connection-to-the-repository]] for details of how to setup SSL connection.
 - [PR-372](https://github.com/Cognifide/knotx/pull/372) - Added cache for compiled Handlebars snippets, you may configure it in Handlebars config, see more in [[Handlebars Knot docs|HandlebarsKnot#how-to-configure]].
- - [PR-374](https://github.com/Cognifide/knotx/pull/374) - Enable keepAlive connection in http client options. This is important fix and we recommend to update your existing configuration of any http client and enable `keepAlive` option.
+- [PR-374](https://github.com/Cognifide/knotx/pull/374) - Enable keepAlive connection in http client options. This is important fix and we recommend to update your existing configuration of any http client and enable `keepAlive` option.
+- [PR-379](https://github.com/Cognifide/knotx/pull/379) - Added access logging capabilities to the Knotx HTTP Server. Establish standard configuration of logback logger. Check [[Configure Access Log|Server#configure-access-log]] to see how to configure access logs, and [[Logging|Logging]] to see how loggers can be configured to log to console, files for knot.x, access & netty logs.
+
 
 ## Version 1.1.2
 - [PR-335](https://github.com/Cognifide/knotx/pull/335) - Added support for HttpServerOptions on the configuration level.

--- a/documentation/src/main/wiki/_Sidebar.md
+++ b/documentation/src/main/wiki/_Sidebar.md
@@ -27,6 +27,7 @@
   * [[Mocks|Mocks]]
   * [[Knot.x Deployment|KnotxDeployment]]
     * [[Knot.x Tuning|KnotxTuning]]
+  * [[Logging|Logging]]
   * [[Performance|PerformanceTests]]
     * [[Performance Tests Methodology|PerformanceTestsMethodology]]
     * [[Performance Tests Summary|PerformanceTestsSummary]]

--- a/knotx-adapter/knotx-adapter-common/src/test/resources/logback-test.xml
+++ b/knotx-adapter/knotx-adapter-common/src/test/resources/logback-test.xml
@@ -17,22 +17,14 @@
 
 -->
 <configuration>
+  <include resource="io/knotx/logging/logback/defaults.xml" />
+  <include resource="io/knotx/logging/logback/console-appender.xml" />
 
-  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
-    <layout class="ch.qos.logback.classic.PatternLayout">
-      <Pattern>
-        %d{yyyy-MM-dd HH:mm:ss} [%thread] %-5level %logger{36} - %msg%n
-      </Pattern>
-    </layout>
-  </appender>
-
-  <logger name="io.knotx.action.http" level="INFO"
-          additivity="false">
-    <appender-ref ref="STDOUT"/>
-  </logger>
-
-  <root level="ERROR">
-    <appender-ref ref="STDOUT"/>
+  <root level="INFO">
+    <appender-ref ref="CONSOLE" />
   </root>
 
+  <logger name="io.knotx" level="TRACE">
+    <appender-ref ref="CONSOLE"/>
+  </logger>
 </configuration>

--- a/knotx-adapter/knotx-adapter-service-http/src/test/resources/logback-test.xml
+++ b/knotx-adapter/knotx-adapter-service-http/src/test/resources/logback-test.xml
@@ -17,22 +17,14 @@
 
 -->
 <configuration>
+  <include resource="io/knotx/logging/logback/defaults.xml" />
+  <include resource="io/knotx/logging/logback/console-appender.xml" />
 
-  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
-    <layout class="ch.qos.logback.classic.PatternLayout">
-      <Pattern>
-        %d{yyyy-MM-dd HH:mm:ss} [%thread] %-5level %logger{36} - %msg%n
-      </Pattern>
-    </layout>
-  </appender>
-
-  <logger name="io.knotx.adapter.service.http" level="TRACE"
-          additivity="false">
-    <appender-ref ref="STDOUT"/>
-  </logger>
-
-  <root level="ERROR">
-    <appender-ref ref="STDOUT"/>
+  <root level="INFO">
+    <appender-ref ref="CONSOLE" />
   </root>
 
+  <logger name="io.knotx" level="TRACE">
+    <appender-ref ref="CONSOLE"/>
+  </logger>
 </configuration>

--- a/knotx-core/src/main/java/io/knotx/launcher/LogbackLauncher.java
+++ b/knotx-core/src/main/java/io/knotx/launcher/LogbackLauncher.java
@@ -29,12 +29,6 @@ public class LogbackLauncher extends Launcher {
   public static final int KNOTX_MISSING_OR_EMPTY_CONFIGURATION_EXIT_CODE = 30;
 
   public static void main(String[] args){
-    try {
-      System.setOut(new PrintStream("/Users/marcin.czeczko/Cognifide/Projects/knotx/knotx-example/knotx-example-app/stdout.log"));
-    } catch (FileNotFoundException e) {
-      e.printStackTrace();
-    }
-
     System.setProperty("vertx.logger-delegate-factory-class-name",
         "io.vertx.core.logging.SLF4JLogDelegateFactory");
     new LogbackLauncher().dispatch(args);

--- a/knotx-core/src/main/java/io/knotx/launcher/LogbackLauncher.java
+++ b/knotx-core/src/main/java/io/knotx/launcher/LogbackLauncher.java
@@ -18,6 +18,8 @@ package io.knotx.launcher;
 import io.vertx.core.Launcher;
 import io.vertx.core.impl.launcher.commands.ExecUtils;
 import io.vertx.core.json.JsonObject;
+import java.io.FileNotFoundException;
+import java.io.PrintStream;
 
 public class LogbackLauncher extends Launcher {
 
@@ -26,7 +28,13 @@ public class LogbackLauncher extends Launcher {
    */
   public static final int KNOTX_MISSING_OR_EMPTY_CONFIGURATION_EXIT_CODE = 30;
 
-  public static void main(String[] args) {
+  public static void main(String[] args){
+    try {
+      System.setOut(new PrintStream("/Users/marcin.czeczko/Cognifide/Projects/knotx/knotx-example/knotx-example-app/stdout.log"));
+    } catch (FileNotFoundException e) {
+      e.printStackTrace();
+    }
+
     System.setProperty("vertx.logger-delegate-factory-class-name",
         "io.vertx.core.logging.SLF4JLogDelegateFactory");
     new LogbackLauncher().dispatch(args);

--- a/knotx-core/src/main/resources/io/knotx/logging/logback/access-file-appender.xml
+++ b/knotx-core/src/main/resources/io/knotx/logging/logback/access-file-appender.xml
@@ -16,10 +16,20 @@
     limitations under the License.
 
 -->
-<configuration>
-  <property name="LOG_PATH" value="${PWD}/logs"/>
+<!--
+File appender logback configuration provided for import
+-->
 
-  <include resource="io/knotx/logging/logback/base.xml" />
-  <include resource="io/knotx/logging/logback/access.xml" />
-
-</configuration>
+<included>
+  <appender name="ACCESS" class="ch.qos.logback.core.rolling.RollingFileAppender">
+    <encoder>
+      <pattern>${FILE_ACCESS_LOG_PATTERN}</pattern>
+    </encoder>
+    <file>${ACCESS_LOG_FILE}</file>
+    <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+      <fileNamePattern>${ACCESS_LOG_FILE}.%d{yyyy-MM-dd}.%i.gz</fileNamePattern>
+      <maxFileSize>${ACCESS_LOG_FILE_MAX_SIZE:-10MB}</maxFileSize>
+      <maxHistory>${ACCESS_LOG_FILE_MAX_HISTORY:-0}</maxHistory>
+    </rollingPolicy>
+  </appender>
+</included>

--- a/knotx-core/src/main/resources/io/knotx/logging/logback/access.xml
+++ b/knotx-core/src/main/resources/io/knotx/logging/logback/access.xml
@@ -22,7 +22,7 @@ File appender logback configuration for knotx access logs provided for import
 
 <included>
   <property name="FILE_ACCESS_LOG_PATTERN" value="%msg%n"/>
-  <property name="ACCESS_LOG_FILE" value="${ACCESS_LOG_FILE:-${LOG_PATH:-${LOG_TEMP:-${java.io.tmpdir:-/tmp}}}/knotx-access.log}"/>
+  <property name="ACCESS_LOG_FILE" value="${LOG_PATH}/knotx-access.log"/>
   <include resource="io/knotx/logging/logback/access-file-appender.xml"/>
 
   <logger name="io.vertx.ext.web.handler.impl.LoggerHandlerImpl" level="INFO" additivity="false">

--- a/knotx-core/src/main/resources/io/knotx/logging/logback/access.xml
+++ b/knotx-core/src/main/resources/io/knotx/logging/logback/access.xml
@@ -16,10 +16,16 @@
     limitations under the License.
 
 -->
-<configuration>
-  <property name="LOG_PATH" value="${PWD}/logs"/>
+<!--
+File appender logback configuration for knotx access logs provided for import
+-->
 
-  <include resource="io/knotx/logging/logback/base.xml" />
-  <include resource="io/knotx/logging/logback/access.xml" />
+<included>
+  <property name="FILE_ACCESS_LOG_PATTERN" value="%msg%n"/>
+  <property name="ACCESS_LOG_FILE" value="${ACCESS_LOG_FILE:-${LOG_PATH:-${LOG_TEMP:-${java.io.tmpdir:-/tmp}}}/knotx-access.log}"/>
+  <include resource="io/knotx/logging/logback/access-file-appender.xml"/>
 
-</configuration>
+  <logger name="io.vertx.ext.web.handler.impl.LoggerHandlerImpl" level="INFO" additivity="false">
+    <appender-ref ref="ACCESS" />
+  </logger>
+</included>

--- a/knotx-core/src/main/resources/io/knotx/logging/logback/base.xml
+++ b/knotx-core/src/main/resources/io/knotx/logging/logback/base.xml
@@ -16,10 +16,22 @@
     limitations under the License.
 
 -->
-<configuration>
+<!--
+Base logback configuration for knot.x
+-->
+<included>
+  <statusListener class="ch.qos.logback.core.status.OnConsoleStatusListener" />
+
   <property name="LOG_PATH" value="${PWD}/logs"/>
 
-  <include resource="io/knotx/logging/logback/base.xml" />
-  <include resource="io/knotx/logging/logback/access.xml" />
+  <include resource="io/knotx/logging/logback/defaults.xml" />
+  <property name="KNOTX_LOG_FILE" value="${KNOTX_LOG_FILE:-${LOG_PATH:-${LOG_TEMP:-${java.io.tmpdir:-/tmp}}}/knotx.log}"/>
 
-</configuration>
+  <include resource="io/knotx/logging/logback/console-appender.xml" />
+  <include resource="io/knotx/logging/logback/file-appender.xml" />
+
+  <root level="INFO">
+    <appender-ref ref="CONSOLE" />
+    <appender-ref ref="FILE" />
+  </root>
+</included>

--- a/knotx-core/src/main/resources/io/knotx/logging/logback/base.xml
+++ b/knotx-core/src/main/resources/io/knotx/logging/logback/base.xml
@@ -22,11 +22,7 @@ Base logback configuration for knot.x
 <included>
   <statusListener class="ch.qos.logback.core.status.OnConsoleStatusListener" />
 
-  <property name="LOG_PATH" value="${PWD}/logs"/>
-
   <include resource="io/knotx/logging/logback/defaults.xml" />
-  <property name="KNOTX_LOG_FILE" value="${KNOTX_LOG_FILE:-${LOG_PATH:-${LOG_TEMP:-${java.io.tmpdir:-/tmp}}}/knotx.log}"/>
-
   <include resource="io/knotx/logging/logback/console-appender.xml" />
   <include resource="io/knotx/logging/logback/file-appender.xml" />
 

--- a/knotx-core/src/main/resources/io/knotx/logging/logback/base.xml
+++ b/knotx-core/src/main/resources/io/knotx/logging/logback/base.xml
@@ -20,14 +20,12 @@
 Base logback configuration for knot.x
 -->
 <included>
-  <statusListener class="ch.qos.logback.core.status.OnConsoleStatusListener" />
-
-  <include resource="io/knotx/logging/logback/defaults.xml" />
-  <include resource="io/knotx/logging/logback/console-appender.xml" />
-  <include resource="io/knotx/logging/logback/file-appender.xml" />
+  <include resource="io/knotx/logging/logback/defaults.xml"/>
+  <include resource="io/knotx/logging/logback/console-appender.xml"/>
+  <include resource="io/knotx/logging/logback/file-appender.xml"/>
 
   <root level="INFO">
-    <appender-ref ref="CONSOLE" />
-    <appender-ref ref="FILE" />
+    <appender-ref ref="CONSOLE"/>
+    <appender-ref ref="FILE"/>
   </root>
 </included>

--- a/knotx-core/src/main/resources/io/knotx/logging/logback/console-appender.xml
+++ b/knotx-core/src/main/resources/io/knotx/logging/logback/console-appender.xml
@@ -16,10 +16,14 @@
     limitations under the License.
 
 -->
-<configuration>
-  <property name="LOG_PATH" value="${PWD}/logs"/>
+<!--
+Console appender logback configuration provided for import
+-->
 
-  <include resource="io/knotx/logging/logback/base.xml" />
-  <include resource="io/knotx/logging/logback/access.xml" />
-
-</configuration>
+<included>
+  <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder>
+      <pattern>${CONSOLE_KNOTX_LOG_PATTERN}</pattern>
+    </encoder>
+  </appender>
+</included>

--- a/knotx-core/src/main/resources/io/knotx/logging/logback/defaults.xml
+++ b/knotx-core/src/main/resources/io/knotx/logging/logback/defaults.xml
@@ -21,8 +21,12 @@ Default logback configuration provided for import
 -->
 
 <included>
+  <property name="LOG_PATH" value="${LOG_PATH:-./logs}"/>
+
   <property name="CONSOLE_KNOTX_LOG_PATTERN" value="%d{${KNOTX_LOG_DATEFORMAT_PATTERN:-yyyy-MM-dd HH:mm:ss.SSS}} [%thread] %-5level %logger{36} - %msg%n"/>
   <property name="FILE_KNOTX_LOG_PATTERN" value="%d{${KNOTX_LOG_DATEFORMAT_PATTERN:-yyyy-MM-dd HH:mm:ss.SSS}} [%thread] %-5level %logger{36} - %msg%n"/>
+
+  <property name="KNOTX_LOG_FILE" value="${LOG_PATH}/knotx.log"/>
 
   <logger name="io.netty" level="ERROR"/>
   <logger name="io.vertx" level="ERROR"/>

--- a/knotx-core/src/main/resources/io/knotx/logging/logback/defaults.xml
+++ b/knotx-core/src/main/resources/io/knotx/logging/logback/defaults.xml
@@ -21,6 +21,8 @@ Default logback configuration provided for import
 -->
 
 <included>
+  <statusListener class="ch.qos.logback.core.status.OnConsoleStatusListener"/>
+
   <property name="LOG_PATH" value="${LOG_PATH:-./logs}"/>
 
   <property name="CONSOLE_KNOTX_LOG_PATTERN" value="%d{${KNOTX_LOG_DATEFORMAT_PATTERN:-yyyy-MM-dd HH:mm:ss.SSS}} [%thread] %-5level %logger{36} - %msg%n"/>

--- a/knotx-core/src/main/resources/io/knotx/logging/logback/defaults.xml
+++ b/knotx-core/src/main/resources/io/knotx/logging/logback/defaults.xml
@@ -16,10 +16,15 @@
     limitations under the License.
 
 -->
-<configuration>
-  <property name="LOG_PATH" value="${PWD}/logs"/>
+<!--
+Default logback configuration provided for import
+-->
 
-  <include resource="io/knotx/logging/logback/base.xml" />
-  <include resource="io/knotx/logging/logback/access.xml" />
+<included>
+  <property name="CONSOLE_KNOTX_LOG_PATTERN" value="%d{${KNOTX_LOG_DATEFORMAT_PATTERN:-yyyy-MM-dd HH:mm:ss.SSS}} [%thread] %-5level %logger{36} - %msg%n"/>
+  <property name="FILE_KNOTX_LOG_PATTERN" value="%d{${KNOTX_LOG_DATEFORMAT_PATTERN:-yyyy-MM-dd HH:mm:ss.SSS}} [%thread] %-5level %logger{36} - %msg%n"/>
 
-</configuration>
+  <logger name="io.netty" level="ERROR"/>
+  <logger name="io.vertx" level="ERROR"/>
+  <logger name="io.knotx" level="INFO"/>
+</included>

--- a/knotx-core/src/main/resources/io/knotx/logging/logback/file-appender.xml
+++ b/knotx-core/src/main/resources/io/knotx/logging/logback/file-appender.xml
@@ -16,10 +16,20 @@
     limitations under the License.
 
 -->
-<configuration>
-  <property name="LOG_PATH" value="${PWD}/logs"/>
+<!--
+File appender logback configuration provided for import
+-->
 
-  <include resource="io/knotx/logging/logback/base.xml" />
-  <include resource="io/knotx/logging/logback/access.xml" />
-
-</configuration>
+<included>
+  <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+    <encoder>
+      <pattern>${FILE_KNOTX_LOG_PATTERN}</pattern>
+    </encoder>
+    <file>${KNOTX_LOG_FILE}</file>
+    <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+      <fileNamePattern>${KNOTX_LOG_FILE}.%d{yyyy-MM-dd}.%i.gz</fileNamePattern>
+      <maxFileSize>${KNOTX_LOG_FILE_MAX_SIZE:-10MB}</maxFileSize>
+      <maxHistory>${KNOTX_LOG_FILE_MAX_HISTORY:-0}</maxHistory>
+    </rollingPolicy>
+  </appender>
+</included>

--- a/knotx-core/src/main/resources/io/knotx/logging/logback/netty-file-appender.xml
+++ b/knotx-core/src/main/resources/io/knotx/logging/logback/netty-file-appender.xml
@@ -16,10 +16,20 @@
     limitations under the License.
 
 -->
-<configuration>
-  <property name="LOG_PATH" value="${PWD}/logs"/>
+<!--
+File appender logback configuration provided for import
+-->
 
-  <include resource="io/knotx/logging/logback/base.xml" />
-  <include resource="io/knotx/logging/logback/access.xml" />
-
-</configuration>
+<included>
+  <appender name="NETTY" class="ch.qos.logback.core.rolling.RollingFileAppender">
+    <encoder>
+      <pattern>${FILE_NETTY_LOG_PATTERN}</pattern>
+    </encoder>
+    <file>${NETTY_LOG_FILE}</file>
+    <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+      <fileNamePattern>${NETTY_LOG_FILE}.%d{yyyy-MM-dd}.%i.gz</fileNamePattern>
+      <maxFileSize>${NETTY_LOG_FILE_MAX_SIZE:-10MB}</maxFileSize>
+      <maxHistory>${NETTY_LOG_FILE_MAX_HISTORY:-0}</maxHistory>
+    </rollingPolicy>
+  </appender>
+</included>

--- a/knotx-core/src/main/resources/io/knotx/logging/logback/netty.xml
+++ b/knotx-core/src/main/resources/io/knotx/logging/logback/netty.xml
@@ -22,7 +22,7 @@ File appender logback configuration for netty debug logs provided for import
 
 <included>
   <property name="FILE_NETTY_LOG_PATTERN" value="%d{${KNOTX_LOG_DATEFORMAT_PATTERN:-yyyy-MM-dd HH:mm:ss.SSS}} [%thread] %-5level %logger{36} - %msg%n"/>
-  <property name="NETTY_LOG_FILE" value="${NETTY_LOG_FILE:-${LOG_PATH:-${LOG_TEMP:-${java.io.tmpdir:-/tmp}}}/knotx-netty.log}"/>
+  <property name="NETTY_LOG_FILE" value="${LOG_PATH}/knotx-netty.log"/>
   <include resource="io/knotx/logging/logback/netty-file-appender.xml"/>
 
   <logger name="io.netty.handler.logging.LoggingHandler" level="DEBUG" additivity="false">

--- a/knotx-core/src/main/resources/io/knotx/logging/logback/netty.xml
+++ b/knotx-core/src/main/resources/io/knotx/logging/logback/netty.xml
@@ -16,10 +16,16 @@
     limitations under the License.
 
 -->
-<configuration>
-  <property name="LOG_PATH" value="${PWD}/logs"/>
+<!--
+File appender logback configuration for netty debug logs provided for import
+-->
 
-  <include resource="io/knotx/logging/logback/base.xml" />
-  <include resource="io/knotx/logging/logback/access.xml" />
+<included>
+  <property name="FILE_NETTY_LOG_PATTERN" value="%d{${KNOTX_LOG_DATEFORMAT_PATTERN:-yyyy-MM-dd HH:mm:ss.SSS}} [%thread] %-5level %logger{36} - %msg%n"/>
+  <property name="NETTY_LOG_FILE" value="${NETTY_LOG_FILE:-${LOG_PATH:-${LOG_TEMP:-${java.io.tmpdir:-/tmp}}}/knotx-netty.log}"/>
+  <include resource="io/knotx/logging/logback/netty-file-appender.xml"/>
 
-</configuration>
+  <logger name="io.netty.handler.logging.LoggingHandler" level="DEBUG" additivity="false">
+    <appender-ref ref="NETTY" />
+  </logger>
+</included>

--- a/knotx-example/knotx-example-action-adapter-http/src/test/resources/logback-test.xml
+++ b/knotx-example/knotx-example-action-adapter-http/src/test/resources/logback-test.xml
@@ -17,22 +17,14 @@
 
 -->
 <configuration>
+  <include resource="io/knotx/logging/logback/defaults.xml" />
+  <include resource="io/knotx/logging/logback/console-appender.xml" />
 
-  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
-    <layout class="ch.qos.logback.classic.PatternLayout">
-      <Pattern>
-        %d{yyyy-MM-dd HH:mm:ss} [%thread] %-5level %logger{36} - %msg%n
-      </Pattern>
-    </layout>
-  </appender>
-
-  <logger name="io.knotx.adapter.common" level="INFO"
-          additivity="false">
-    <appender-ref ref="STDOUT"/>
-  </logger>
-
-  <root level="ERROR">
-    <appender-ref ref="STDOUT"/>
+  <root level="INFO">
+    <appender-ref ref="CONSOLE" />
   </root>
 
+  <logger name="io.knotx" level="TRACE">
+    <appender-ref ref="CONSOLE"/>
+  </logger>
 </configuration>

--- a/knotx-example/knotx-example-app/src/main/resources/example.io.knotx.KnotxServer.json
+++ b/knotx-example/knotx-example-app/src/main/resources/example.io.knotx.KnotxServer.json
@@ -4,7 +4,8 @@
     "config": {
       "serverOptions": {
         "port": 8092,
-        "keyStoreOptions": {}
+        "keyStoreOptions": {},
+        "logActivity": true
       },
       "displayExceptionDetails": true,
       "customResponseHeader": {

--- a/knotx-example/knotx-example-app/src/main/resources/knotx-example-app.json
+++ b/knotx-example/knotx-example-app/src/main/resources/knotx-example-app.json
@@ -19,6 +19,15 @@
     "knotx:io.knotx.ResponseProviderKnot"
   ],
   "config": {
+    "knotx:io.knotx.HttpServiceAdapter": {
+      "options": {
+        "config": {
+          "clientOptions": {
+            "logActivity": true
+          }
+        }
+      }
+    },
     "knotx:io.knotx.ServiceKnot": {
       "options": {
         "config": {
@@ -56,6 +65,9 @@
     "knotx:example.io.knotx.HttpActionAdapter": {
       "options": {
         "config": {
+          "clientOptions": {
+            "logActivity": true
+          },
           "allowedRequestHeaders": [
             "Cookie",
             "Content-Type",

--- a/knotx-example/knotx-example-app/src/main/resources/logback.xml
+++ b/knotx-example/knotx-example-app/src/main/resources/logback.xml
@@ -17,52 +17,30 @@
 
 -->
 <configuration scan="true">
-  <statusListener class="ch.qos.logback.core.status.OnConsoleStatusListener" />
+  <property name="LOG_PATH" value="${PWD}/logs"/>
+  <property name="NETTY_LOG_FILE_MAX_SIZE" value="1KB"/>
 
-  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
-    <encoder>
-      <Pattern>
-        %d{yyyy-MM-dd HH:mm:ss} [%thread] %-5level %logger{36} - %msg%n
-      </Pattern>
-    </encoder>
-  </appender>
+  <include resource="io/knotx/logging/logback/base.xml" />
+  <include resource="io/knotx/logging/logback/access.xml" />
+  <include resource="io/knotx/logging/logback/netty.xml" />
 
-  <appender name="netty-wire" class="ch.qos.logback.core.FileAppender">
-    <file>netty-wire.log</file>
-    <append>true</append>
+  <!-- Increase logging level for Knot.x -->
+  <logger name="io.knotx" level="DEBUG" />
 
-    <encoder>
-      <Pattern>
-        %d{yyyy-MM-dd HH:mm:ss} [%thread] %-5level %logger{36} - %msg%n
-      </Pattern>
-    </encoder>
-  </appender>
-
-  <appender name="access" class="ch.qos.logback.core.FileAppender">
-    <file>access.log</file>
+  <appender name="ALOG" class="ch.qos.logback.core.FileAppender">
+    <file>logger.log</file>
     <append>true</append>
     <!-- set immediateFlush to false for much higher logging throughput -->
     <immediateFlush>true</immediateFlush>
+    <!-- encoders are assigned the type
+         ch.qos.logback.classic.encoder.PatternLayoutEncoder by default -->
     <encoder>
-      <pattern>%msg%n</pattern>
+      <pattern>%-4relative [%thread] %-5level %logger{35} - %msg%n</pattern>
     </encoder>
   </appender>
 
-  <logger name="io.vertx.ext.web.handler.impl.LoggerHandlerImpl" level="INFO" additivity="false">
-    <appender-ref ref="access"/>
+  <logger name="ch.qos.logback" level="INFO" additivity="false">
+    <appender-ref ref="ALOG" />
   </logger>
-
-  <logger name="io.netty.handler.logging" level="TRACE" additivity="false">
-    <appender-ref ref="netty-wire"/>
-  </logger>
-
-  <logger name="io.knotx" level="DEBUG"
-          additivity="false">
-    <appender-ref ref="STDOUT"/>
-  </logger>
-
-  <root level="ERROR">
-    <appender-ref ref="STDOUT"/>
-  </root>
 
 </configuration>

--- a/knotx-example/knotx-example-app/src/main/resources/logback.xml
+++ b/knotx-example/knotx-example-app/src/main/resources/logback.xml
@@ -38,6 +38,20 @@
     </encoder>
   </appender>
 
+  <appender name="access" class="ch.qos.logback.core.FileAppender">
+    <file>access.log</file>
+    <append>true</append>
+    <!-- set immediateFlush to false for much higher logging throughput -->
+    <immediateFlush>true</immediateFlush>
+    <encoder>
+      <pattern>%d{yyyy-MM-dd HH:mm:ss} [%thread] %-5level %logger{36} - %msg%n</pattern>
+    </encoder>
+  </appender>
+
+  <logger name="io.vertx.ext.web.handler.impl.LoggerHandlerImpl" level="INFO" additivity="false">
+    <appender-ref ref="access"/>
+  </logger>
+
   <logger name="io.netty.handler.logging" level="TRACE" additivity="false">
     <appender-ref ref="netty-wire"/>
   </logger>

--- a/knotx-example/knotx-example-app/src/main/resources/logback.xml
+++ b/knotx-example/knotx-example-app/src/main/resources/logback.xml
@@ -44,7 +44,7 @@
     <!-- set immediateFlush to false for much higher logging throughput -->
     <immediateFlush>true</immediateFlush>
     <encoder>
-      <pattern>%d{yyyy-MM-dd HH:mm:ss} [%thread] %-5level %logger{36} - %msg%n</pattern>
+      <pattern>%msg%n</pattern>
     </encoder>
   </appender>
 

--- a/knotx-example/knotx-example-app/src/main/resources/logback.xml
+++ b/knotx-example/knotx-example-app/src/main/resources/logback.xml
@@ -17,30 +17,11 @@
 
 -->
 <configuration scan="true">
-  <property name="LOG_PATH" value="${PWD}/logs"/>
-  <property name="NETTY_LOG_FILE_MAX_SIZE" value="1KB"/>
-
   <include resource="io/knotx/logging/logback/base.xml" />
   <include resource="io/knotx/logging/logback/access.xml" />
   <include resource="io/knotx/logging/logback/netty.xml" />
 
   <!-- Increase logging level for Knot.x -->
   <logger name="io.knotx" level="DEBUG" />
-
-  <appender name="ALOG" class="ch.qos.logback.core.FileAppender">
-    <file>logger.log</file>
-    <append>true</append>
-    <!-- set immediateFlush to false for much higher logging throughput -->
-    <immediateFlush>true</immediateFlush>
-    <!-- encoders are assigned the type
-         ch.qos.logback.classic.encoder.PatternLayoutEncoder by default -->
-    <encoder>
-      <pattern>%-4relative [%thread] %-5level %logger{35} - %msg%n</pattern>
-    </encoder>
-  </appender>
-
-  <logger name="ch.qos.logback" level="INFO" additivity="false">
-    <appender-ref ref="ALOG" />
-  </logger>
 
 </configuration>

--- a/knotx-example/knotx-example-app/src/main/resources/logback.xml
+++ b/knotx-example/knotx-example-app/src/main/resources/logback.xml
@@ -23,5 +23,4 @@
 
   <!-- Increase logging level for Knot.x -->
   <logger name="io.knotx" level="DEBUG" />
-
 </configuration>

--- a/knotx-example/knotx-example-app/src/test/resources/logback-test.xml
+++ b/knotx-example/knotx-example-app/src/test/resources/logback-test.xml
@@ -17,22 +17,14 @@
 
 -->
 <configuration>
+  <include resource="io/knotx/logging/logback/defaults.xml" />
+  <include resource="io/knotx/logging/logback/console-appender.xml" />
 
-  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
-    <layout class="ch.qos.logback.classic.PatternLayout">
-      <Pattern>
-        %d{yyyy-MM-dd HH:mm:ss} [%thread] %-5level %logger{36} - %msg%n
-      </Pattern>
-    </layout>
-  </appender>
-
-  <logger name="io.knotx" level="TRACE"
-          additivity="false">
-    <appender-ref ref="STDOUT"/>
-  </logger>
-
-  <root level="ERROR">
-    <appender-ref ref="STDOUT"/>
+  <root level="INFO">
+    <appender-ref ref="CONSOLE" />
   </root>
 
+  <logger name="io.knotx" level="TRACE">
+    <appender-ref ref="CONSOLE"/>
+  </logger>
 </configuration>

--- a/knotx-knot/knotx-knot-action/src/test/resources/logback-test.xml
+++ b/knotx-knot/knotx-knot-action/src/test/resources/logback-test.xml
@@ -17,22 +17,14 @@
 
 -->
 <configuration>
+  <include resource="io/knotx/logging/logback/defaults.xml" />
+  <include resource="io/knotx/logging/logback/console-appender.xml" />
 
-  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
-    <layout class="ch.qos.logback.classic.PatternLayout">
-      <Pattern>
-        %d{yyyy-MM-dd HH:mm:ss} [%thread] %-5level %logger{36} - %msg%n
-      </Pattern>
-    </layout>
-  </appender>
-
-  <logger name="io.knotx.knot.action" level="INFO"
-          additivity="false">
-    <appender-ref ref="STDOUT"/>
-  </logger>
-
-  <root level="ERROR">
-    <appender-ref ref="STDOUT"/>
+  <root level="INFO">
+    <appender-ref ref="CONSOLE" />
   </root>
 
+  <logger name="io.knotx" level="TRACE">
+    <appender-ref ref="CONSOLE"/>
+  </logger>
 </configuration>

--- a/knotx-knot/knotx-knot-fragment-splitter/src/test/resources/logback-test.xml
+++ b/knotx-knot/knotx-knot-fragment-splitter/src/test/resources/logback-test.xml
@@ -17,22 +17,14 @@
 
 -->
 <configuration>
+  <include resource="io/knotx/logging/logback/defaults.xml" />
+  <include resource="io/knotx/logging/logback/console-appender.xml" />
 
-  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
-    <layout class="ch.qos.logback.classic.PatternLayout">
-      <Pattern>
-        %d{yyyy-MM-dd HH:mm:ss} [%thread] %-5level %logger{36} - %msg%n
-      </Pattern>
-    </layout>
-  </appender>
-
-  <logger name="io.knotx" level="TRACE"
-          additivity="false">
-    <appender-ref ref="STDOUT"/>
-  </logger>
-
-  <root level="ERROR">
-    <appender-ref ref="STDOUT"/>
+  <root level="INFO">
+    <appender-ref ref="CONSOLE" />
   </root>
 
+  <logger name="io.knotx" level="TRACE">
+    <appender-ref ref="CONSOLE"/>
+  </logger>
 </configuration>

--- a/knotx-knot/knotx-knot-handlebars/src/test/resources/logback-test.xml
+++ b/knotx-knot/knotx-knot-handlebars/src/test/resources/logback-test.xml
@@ -17,22 +17,14 @@
 
 -->
 <configuration>
+  <include resource="io/knotx/logging/logback/defaults.xml" />
+  <include resource="io/knotx/logging/logback/console-appender.xml" />
 
-  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
-    <layout class="ch.qos.logback.classic.PatternLayout">
-      <Pattern>
-        %d{yyyy-MM-dd HH:mm:ss} [%thread] %-5level %logger{36} - %msg%n
-      </Pattern>
-    </layout>
-  </appender>
-
-  <logger name="io.knotx.knot.service" level="INFO"
-          additivity="false">
-    <appender-ref ref="STDOUT"/>
-  </logger>
-
-  <root level="ERROR">
-    <appender-ref ref="STDOUT"/>
+  <root level="INFO">
+    <appender-ref ref="CONSOLE" />
   </root>
 
+  <logger name="io.knotx" level="TRACE">
+    <appender-ref ref="CONSOLE"/>
+  </logger>
 </configuration>

--- a/knotx-knot/knotx-knot-service/src/test/resources/logback-test.xml
+++ b/knotx-knot/knotx-knot-service/src/test/resources/logback-test.xml
@@ -17,22 +17,14 @@
 
 -->
 <configuration>
+  <include resource="io/knotx/logging/logback/defaults.xml" />
+  <include resource="io/knotx/logging/logback/console-appender.xml" />
 
-  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
-    <layout class="ch.qos.logback.classic.PatternLayout">
-      <Pattern>
-        %d{yyyy-MM-dd HH:mm:ss} [%thread] %-5level %logger{36} - %msg%n
-      </Pattern>
-    </layout>
-  </appender>
-
-  <logger name="io.knotx.knot.templating" level="TEST"
-          additivity="false">
-    <appender-ref ref="STDOUT"/>
-  </logger>
-
-  <root level="ERROR">
-    <appender-ref ref="STDOUT"/>
+  <root level="INFO">
+    <appender-ref ref="CONSOLE" />
   </root>
 
+  <logger name="io.knotx" level="TRACE">
+    <appender-ref ref="CONSOLE"/>
+  </logger>
 </configuration>

--- a/knotx-server/src/main/java/io/knotx/server/KnotxRepositoryHandler.java
+++ b/knotx-server/src/main/java/io/knotx/server/KnotxRepositoryHandler.java
@@ -60,7 +60,8 @@ public class KnotxRepositoryHandler implements Handler<RoutingContext> {
     final KnotContext knotContext = context.get(KnotContext.KEY);
 
     if (repositoryEntry.isPresent()) {
-      proxies.computeIfAbsent( repositoryEntry.get().address(),adr -> RepositoryConnectorProxy.createProxyWithOptions(vertx, adr, configuration.getDeliveryOptions()))
+      proxies.computeIfAbsent(repositoryEntry.get().address(), adr -> RepositoryConnectorProxy
+          .createProxyWithOptions(vertx, adr, configuration.getDeliveryOptions()))
           .rxProcess(knotContext.getClientRequest())
           .doOnSuccess(this::traceMessage)
           .subscribe(
@@ -91,8 +92,12 @@ public class KnotxRepositoryHandler implements Handler<RoutingContext> {
 
   private void endResponse(ClientResponse repoResponse, RoutingContext context) {
     writeHeaders(context.response(), repoResponse.getHeaders());
-    context.response().setStatusCode(repoResponse.getStatusCode())
-        .end(Buffer.newInstance(repoResponse.getBody()));
+    context.response().setStatusCode(repoResponse.getStatusCode());
+    if (repoResponse.getBody() != null) {
+      context.response().end(Buffer.newInstance(repoResponse.getBody()));
+    } else {
+      context.response().end();
+    }
   }
 
   private boolean isSuccessResponse(ClientResponse repoResponse) {

--- a/knotx-server/src/main/java/io/knotx/server/KnotxServerVerticle.java
+++ b/knotx-server/src/main/java/io/knotx/server/KnotxServerVerticle.java
@@ -31,8 +31,7 @@ import io.vertx.reactivex.ext.web.handler.BodyHandler;
 import io.vertx.reactivex.ext.web.handler.CSRFHandler;
 import io.vertx.reactivex.ext.web.handler.CookieHandler;
 import io.vertx.reactivex.ext.web.handler.ErrorHandler;
-import java.io.IOException;
-import java.net.URISyntaxException;
+import io.vertx.reactivex.ext.web.handler.LoggerHandler;
 
 public class KnotxServerVerticle extends AbstractVerticle {
 
@@ -47,7 +46,7 @@ public class KnotxServerVerticle extends AbstractVerticle {
   }
 
   @Override
-  public void start(Future<Void> fut) throws IOException, URISyntaxException {
+  public void start(Future<Void> fut) {
     LOGGER.info("Starting <{}>", this.getClass().getSimpleName());
     KnotxCSRFConfig csrfConfig = configuration.getCsrfConfig();
     CSRFHandler csrfHandler = CSRFHandler.create(csrfConfig.getSecret())
@@ -58,6 +57,10 @@ public class KnotxServerVerticle extends AbstractVerticle {
         .setTimeout(csrfConfig.getTimeout());
 
     Router router = Router.router(vertx);
+    if (configuration.getAccessLogConfig().isEnabled()) {
+      router.route().handler(LoggerHandler.create(configuration.getAccessLogConfig().isImmediate(),
+          configuration.getAccessLogConfig().getFormat()));
+    }
     router.route().handler(KnotxHeaderHandler.create(configuration));
     router.route().handler(SupportedMethodsAndPathsHandler.create(configuration));
     router.route().handler(CookieHandler.create());

--- a/knotx-server/src/main/java/io/knotx/server/configuration/AccessLogConfig.java
+++ b/knotx-server/src/main/java/io/knotx/server/configuration/AccessLogConfig.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) 2016 Cognifide Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.knotx.server.configuration;
+
+import io.vertx.core.json.JsonObject;
+import io.vertx.ext.web.handler.LoggerFormat;
+
+public class AccessLogConfig {
+
+  public static final boolean DEFAULT_ENABLED = true;
+  public static final boolean DEFAULT_LOGGER_IMMEDIATE = false;
+  public static final String DEFAULT_LOGGER_FORMAT = LoggerFormat.DEFAULT.toString();
+
+  private boolean enabled;
+  private boolean immediate;
+  private LoggerFormat format;
+
+  public AccessLogConfig(JsonObject config) {
+    enabled = config.getBoolean("enabled", DEFAULT_ENABLED);
+    immediate = config.getBoolean("immediate", DEFAULT_LOGGER_IMMEDIATE);
+    format = LoggerFormat
+        .valueOf(config.getString("format", DEFAULT_LOGGER_FORMAT).toUpperCase());
+  }
+
+  public boolean isEnabled() {
+    return enabled;
+  }
+
+  public boolean isImmediate() {
+    return immediate;
+  }
+
+  public LoggerFormat getFormat() {
+    return format;
+  }
+}

--- a/knotx-server/src/main/java/io/knotx/server/configuration/AccessLogConfig.java
+++ b/knotx-server/src/main/java/io/knotx/server/configuration/AccessLogConfig.java
@@ -20,9 +20,9 @@ import io.vertx.ext.web.handler.LoggerFormat;
 
 public class AccessLogConfig {
 
-  public static final boolean DEFAULT_ENABLED = true;
-  public static final boolean DEFAULT_LOGGER_IMMEDIATE = false;
-  public static final String DEFAULT_LOGGER_FORMAT = LoggerFormat.DEFAULT.toString();
+  private static final boolean DEFAULT_ENABLED = true;
+  private static final boolean DEFAULT_LOGGER_IMMEDIATE = false;
+  private static final String DEFAULT_LOGGER_FORMAT = LoggerFormat.DEFAULT.toString();
 
   private boolean enabled;
   private boolean immediate;

--- a/knotx-server/src/main/java/io/knotx/server/configuration/AccessLogConfig.java
+++ b/knotx-server/src/main/java/io/knotx/server/configuration/AccessLogConfig.java
@@ -24,9 +24,9 @@ public class AccessLogConfig {
   private static final boolean DEFAULT_LOGGER_IMMEDIATE = false;
   private static final String DEFAULT_LOGGER_FORMAT = LoggerFormat.DEFAULT.toString();
 
-  private boolean enabled;
-  private boolean immediate;
-  private LoggerFormat format;
+  private final boolean enabled;
+  private final boolean immediate;
+  private final LoggerFormat format;
 
   public AccessLogConfig(JsonObject config) {
     enabled = config.getBoolean("enabled", DEFAULT_ENABLED);

--- a/knotx-server/src/main/java/io/knotx/server/configuration/KnotxServerConfiguration.java
+++ b/knotx-server/src/main/java/io/knotx/server/configuration/KnotxServerConfiguration.java
@@ -46,6 +46,8 @@ public class KnotxServerConfiguration {
 
   private KnotxCSRFConfig csrfConfig;
 
+  private AccessLogConfig accessLogConfig;
+
   public KnotxServerConfiguration(JsonObject config) {
     displayExceptionDetails = config.getBoolean("displayExceptionDetails", false);
 
@@ -67,6 +69,8 @@ public class KnotxServerConfiguration {
             config.getJsonObject("deliveryOptions"))
             : new DeliveryOptions();
     csrfConfig = new KnotxCSRFConfig(config.getJsonObject("csrf", new JsonObject()));
+
+    accessLogConfig = new AccessLogConfig(config.getJsonObject("accessLog", new JsonObject()));
   }
 
   public boolean displayExceptionDetails() {
@@ -107,5 +111,9 @@ public class KnotxServerConfiguration {
 
   public Long getFileUploadLimit() {
     return fileUploadLimit;
+  }
+
+  public AccessLogConfig getAccessLogConfig() {
+    return accessLogConfig;
   }
 }

--- a/knotx-standalone/src/main/resources/logback.xml
+++ b/knotx-standalone/src/main/resources/logback.xml
@@ -17,6 +17,12 @@
 
 -->
 <configuration>
-  <include resource="io/knotx/logging/logback/base.xml" />
+  <include resource="io/knotx/logging/logback/defaults.xml"/>
+  <include resource="io/knotx/logging/logback/file-appender.xml"/>
   <include resource="io/knotx/logging/logback/access.xml" />
+
+  <root level="INFO">
+    <appender-ref ref="CONSOLE"/>
+    <appender-ref ref="FILE"/>
+  </root>
 </configuration>

--- a/knotx-standalone/src/main/resources/logback.xml
+++ b/knotx-standalone/src/main/resources/logback.xml
@@ -26,8 +26,22 @@
     </encoder>
   </appender>
 
+  <appender name="access" class="ch.qos.logback.core.FileAppender">
+    <file>access.log</file>
+    <append>true</append>
+    <!-- set immediateFlush to false for much higher logging throughput -->
+    <immediateFlush>true</immediateFlush>
+    <encoder>
+      <pattern>%msg%n</pattern>
+    </encoder>
+  </appender>
+
+  <logger name="io.vertx.ext.web.handler.impl.LoggerHandlerImpl" level="INFO" additivity="false">
+    <appender-ref ref="access"/>
+  </logger>
+
   <logger name="io.knotx" level="INFO"
-          additivity="false">
+      additivity="false">
     <appender-ref ref="STDOUT"/>
   </logger>
 

--- a/knotx-standalone/src/main/resources/logback.xml
+++ b/knotx-standalone/src/main/resources/logback.xml
@@ -17,9 +17,6 @@
 
 -->
 <configuration>
-  <property name="LOG_PATH" value="${PWD}/logs"/>
-
   <include resource="io/knotx/logging/logback/base.xml" />
   <include resource="io/knotx/logging/logback/access.xml" />
-
 </configuration>


### PR DESCRIPTION

## Description
Added access logging capabilities to the Knotx HTTP Server. The feature uses the Vert.x logging handler so it brings a limited capabilities of the log message configuration, such as:
- Enable/Disable access log
- Logging after request arrives, or after response
- Pick one of the available log formats - DEFAULT (as apache log), SHORT, TINY

Besides, a default logback configuration updated to add additional log appender for a access log.

## Motivation and Context
The operation & maintenance of the Knot.x require the access log information to be able to monitor/trouble shoot the set up.
It partially fixes #378 

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code style](https://github.com/Cognifide/knotx/blob/master/CONTRIBUTING.md#coding-conventions) of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.

---
I hereby agree to the terms of the Knot.x Contributor License Agreement.
