### PR TITLE
Feature/main config location

### DIFF
--- a/documentation/src/main/wiki/GettingStarted.md
+++ b/documentation/src/main/wiki/GettingStarted.md
@@ -28,7 +28,7 @@ First download Knot.x sample app & config for latest version, or build it yourse
 
 Now you can run Knot.x:
 ```
-java -Dvertx.logger-delegate-factory-class-name=io.vertx.core.logging.SLF4JLogDelegateFactory -cp config:lib/knotx-example-app-X.Y.Z-fat.jar io.vertx.core.Launcher run-knotx
+java -Dvertx.logger-delegate-factory-class-name=io.vertx.core.logging.SLF4JLogDelegateFactory -Dknotx.home=. -cp config:lib/knotx-example-app-X.Y.Z-fat.jar io.vertx.core.Launcher run-knotx
 ```
 
 That's all. Finally you can open a browser and type an url `http://localhost:8092/content/local/simple.html`. 

--- a/knotx-core/src/main/java/io/knotx/launcher/BadKnotxConfigurationException.java
+++ b/knotx-core/src/main/java/io/knotx/launcher/BadKnotxConfigurationException.java
@@ -1,0 +1,26 @@
+/*
+/*
+ * Copyright (C) 2016 Cognifide Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.knotx.launcher;
+
+import io.vertx.core.VertxException;
+
+public class BadKnotxConfigurationException extends VertxException {
+
+  public BadKnotxConfigurationException(String message) {
+    super(message);
+  }
+}

--- a/knotx-core/src/main/java/io/knotx/launcher/config/ConfProcessor.java
+++ b/knotx-core/src/main/java/io/knotx/launcher/config/ConfProcessor.java
@@ -96,7 +96,7 @@ public class ConfProcessor implements ConfigProcessor {
     public KnotxConfIncluder(JsonObject configuration) {
       configSearchFolder = Optional.ofNullable(configuration.getString("path"))
           .map(path -> path.substring(0, path.lastIndexOf("/")))
-          .orElse(System.getProperty("user.dir") + "/conf");
+          .orElse(System.getProperty("knotx.home") + "/conf");
     }
 
     @Override

--- a/knotx-core/src/main/java/io/knotx/server/KnotxServerVerticle.java
+++ b/knotx-core/src/main/java/io/knotx/server/KnotxServerVerticle.java
@@ -38,6 +38,7 @@ import io.vertx.reactivex.ext.web.handler.LoggerHandler;
 public class KnotxServerVerticle extends AbstractVerticle {
 
   public static final String KNOTX_PORT_PROP_NAME = "knotx.port";
+  public static final String KNOTX_FILE_UPLOAD_DIR_PROPERTY = "knotx.fileUploadDir";
 
   private static final Logger LOGGER = LoggerFactory.getLogger(KnotxServerVerticle.class);
 

--- a/knotx-core/src/main/java/io/knotx/server/configuration/KnotxServerOptions.java
+++ b/knotx-core/src/main/java/io/knotx/server/configuration/KnotxServerOptions.java
@@ -18,10 +18,11 @@ package io.knotx.server.configuration;
 import static io.knotx.server.KnotxServerVerticle.KNOTX_PORT_PROP_NAME;
 
 import io.knotx.configuration.CustomHttpHeader;
+import io.knotx.server.KnotxServerVerticle;
+import io.knotx.util.StringUtil;
 import io.netty.handler.codec.http.HttpResponseStatus;
 import io.reactivex.BackpressureOverflowStrategy;
 import io.vertx.codegen.annotations.DataObject;
-import io.vertx.codegen.annotations.GenIgnore;
 import io.vertx.core.eventbus.DeliveryOptions;
 import io.vertx.core.http.HttpServerOptions;
 import io.vertx.core.json.JsonObject;
@@ -42,9 +43,11 @@ public class KnotxServerOptions {
   public final static long DEFAULT_UPLOAD_LIMIT = -1;
 
   /**
-   * Default file upload folder =
+   * Default file upload folder = file-uploads
    */
-  private static final String DEFAULT_UPLOAD_DIRECTORY = BodyHandler.DEFAULT_UPLOADS_DIRECTORY;
+  private static final String DEFAULT_UPLOAD_DIRECTORY = StringUtil
+      .getString(KnotxServerVerticle.KNOTX_FILE_UPLOAD_DIR_PROPERTY,
+          BodyHandler.DEFAULT_UPLOADS_DIRECTORY);
 
   /**
    * Default flag if to show the exceptions on error pages = false

--- a/knotx-core/src/main/java/io/knotx/util/StringUtil.java
+++ b/knotx-core/src/main/java/io/knotx/util/StringUtil.java
@@ -1,0 +1,36 @@
+package io.knotx.util;
+
+import org.apache.commons.lang3.StringUtils;
+
+public class StringUtil {
+
+  /**
+   * Returns the string value of the system property with the
+   * specified name. The first argument is treated as the name of a
+   * system property.  System properties are accessible through the
+   * {@link java.lang.System#getProperty(java.lang.String)} method.
+   *
+   * <p>The second argument is the default value. The default value is
+   * returned if there is no property of the specified name or if the
+   * specified name is empty or {@code null}.
+   *
+   * @param propertyName property name.
+   * @param defaultVal default value.
+   * @return the {@code String} value of the property.
+   * @throws SecurityException for the same reasons as {@link System#getProperty(String) System.getProperty}
+   * @see System#getProperty(java.lang.String)
+   * @see System#getProperty(java.lang.String, java.lang.String)
+   */
+  public static String getString(String propertyName, String defaultVal) {
+    String value = null;
+    try {
+      value = System.getProperty(propertyName);
+    } catch (IllegalArgumentException | NullPointerException e) {
+    }
+    if (StringUtils.isNotBlank(value)) {
+      return value;
+    }
+    return defaultVal;
+  }
+
+}

--- a/knotx-example/knotx-example-app/config/bootstrap.json
+++ b/knotx-example/knotx-example-app/config/bootstrap.json
@@ -6,7 +6,7 @@
         "type": "file",
         "format": "conf",
         "config": {
-          "path": "config/application.conf"
+          "path": "${KNOTX_HOME}/config/application.conf"
         }
       }
     ]

--- a/knotx-example/knotx-example-app/config/includes/server.conf
+++ b/knotx-example/knotx-example-app/config/includes/server.conf
@@ -1,4 +1,5 @@
 # Knot.x server HTTP port
+# You can also define that port through JVM system properties, such as -Dknotx.port=9876
 serverOptions.port = ${global.serverPort}
 
 # List of HTTP response headers Knot.x can return to the client
@@ -148,6 +149,7 @@ displayExceptionDetails = true
 # fileUploadLimit =
 
 # Folder where uploaded files will be stored. Default is file-uploads folder in current working directory.
+# You can specify that folder by specifying path through JVM system properties, e.g. -Dknotx.fileUploadDir=/tmp/knotx-file-uploads
 # fileUploadDirectory =
 
 ####### Server backpressure section ########


### PR DESCRIPTION

## Description
Added vertx hooks to properly terminate instance on fatal failure, like missing configurations etc.

## Motivation and Context
- During testing it appeared that Knotx is not shutting down when invoked System.exit() methods, it's due to the fact vertx create shutdown hook that executes proper hooks on each command
- Additionally, added better error control in starter knotx to stop instance for multiple scenarios 
- Added support for `KNOTX_HOME` variable in bootstrap.json, to better control location of config files, especially in dockerized environments

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code style](https://github.com/Cognifide/knotx/blob/master/CONTRIBUTING.md#coding-conventions) of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.

---
I hereby agree to the terms of the Knot.x Contributor License Agreement.
