### PR TITLE
Refactor StringToPatternFunction and add regex escaping

### DIFF
--- a/knotx-adapter/knotx-adapter-common/src/main/java/io/knotx/adapter/common/http/HttpAdapterConfiguration.java
+++ b/knotx-adapter/knotx-adapter-common/src/main/java/io/knotx/adapter/common/http/HttpAdapterConfiguration.java
@@ -51,7 +51,7 @@ public class HttpAdapterConfiguration {
           metadata.setAllowedRequestHeaderPatterns(item
               .getJsonArray("allowedRequestHeaders", new JsonArray()).stream()
               .map(object -> (String) object)
-              .map(new StringToPatternFunction())
+              .map(StringToPatternFunction.getInstance())
               .collect(Collectors.toList())
           );
 

--- a/knotx-core/src/main/java/io/knotx/http/StringToPatternFunction.java
+++ b/knotx-core/src/main/java/io/knotx/http/StringToPatternFunction.java
@@ -27,12 +27,19 @@ public class StringToPatternFunction implements Function<String, Pattern> {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(StringToPatternFunction.class);
 
-  private static final String WILDCARD = "*";
+  private static final StringToPatternFunction INSTANCE = new StringToPatternFunction();
 
+  private static final String WILDCARD = "*";
   private static final String REGEX_START_ESCAPING = "\\Q";
   private static final String REGEX_STOP_ESCAPING = "\\E";
-
   private static final String WILDCARD_REPLACEMENT = REGEX_STOP_ESCAPING + "(.+)" + REGEX_START_ESCAPING;
+
+  private StringToPatternFunction() {
+  }
+
+  public static StringToPatternFunction getInstance() {
+    return INSTANCE;
+  }
 
   @Override
   public Pattern apply(String stringPattern) {

--- a/knotx-core/src/main/java/io/knotx/http/StringToPatternFunction.java
+++ b/knotx-core/src/main/java/io/knotx/http/StringToPatternFunction.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2016 Cognifide Limited
+ * Modifications copyright (C) 2018 Piotr Andruszkiewicz
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,19 +29,29 @@ public class StringToPatternFunction implements Function<String, Pattern> {
 
   private static final String WILDCARD = "*";
 
+  private static final String REGEX_START_ESCAPING = "\\Q";
+  private static final String REGEX_STOP_ESCAPING = "\\E";
+
+  private static final String WILDCARD_REPLACEMENT = REGEX_STOP_ESCAPING + "(.+)" + REGEX_START_ESCAPING;
+
   @Override
   public Pattern apply(String stringPattern) {
-    Pattern compiledPattern;
     try {
-      compiledPattern = Pattern.compile(toRegex(stringPattern), Pattern.CASE_INSENSITIVE);
+      return makePattern(stringPattern);
     } catch (PatternSyntaxException e) {
       LOGGER.error("Invalid configuration syntax: {}", stringPattern, e);
       throw new ConfigurationException("Application error - invalid configuration");
     }
-    return compiledPattern;
+  }
+
+  private Pattern makePattern(String stringPattern) {
+    String regex = toRegex(stringPattern);
+    return Pattern.compile(regex, Pattern.CASE_INSENSITIVE);
   }
 
   private String toRegex(String stringPattern) {
-    return "^" + stringPattern.replace(WILDCARD, "(.+)") + "$";
+    return "^" + REGEX_START_ESCAPING
+        + stringPattern.replace(WILDCARD, WILDCARD_REPLACEMENT)
+        + REGEX_STOP_ESCAPING + "$";
   }
 }

--- a/knotx-core/src/main/java/io/knotx/http/StringToPatternFunction.java
+++ b/knotx-core/src/main/java/io/knotx/http/StringToPatternFunction.java
@@ -1,6 +1,5 @@
 /*
  * Copyright (C) 2016 Cognifide Limited
- * Modifications copyright (C) 2018 Piotr Andruszkiewicz
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,6 +18,7 @@ package io.knotx.http;
 import io.knotx.exceptions.ConfigurationException;
 import io.vertx.core.logging.Logger;
 import io.vertx.core.logging.LoggerFactory;
+
 import java.util.function.Function;
 import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
@@ -30,9 +30,7 @@ public class StringToPatternFunction implements Function<String, Pattern> {
   private static final StringToPatternFunction INSTANCE = new StringToPatternFunction();
 
   private static final String WILDCARD = "*";
-  private static final String REGEX_START_ESCAPING = "\\Q";
-  private static final String REGEX_STOP_ESCAPING = "\\E";
-  private static final String WILDCARD_REPLACEMENT = REGEX_STOP_ESCAPING + "(.+)" + REGEX_START_ESCAPING;
+  private static final String WILDCARD_REPLACEMENT = "(.+)";
 
   private StringToPatternFunction() {
   }
@@ -57,8 +55,6 @@ public class StringToPatternFunction implements Function<String, Pattern> {
   }
 
   private String toRegex(String stringPattern) {
-    return "^" + REGEX_START_ESCAPING
-        + stringPattern.replace(WILDCARD, WILDCARD_REPLACEMENT)
-        + REGEX_STOP_ESCAPING + "$";
+    return "^" + stringPattern.replace(WILDCARD, WILDCARD_REPLACEMENT) + "$";
   }
 }

--- a/knotx-core/src/test/java/io/knotx/http/AllowedHeadersFilterTest.java
+++ b/knotx-core/src/test/java/io/knotx/http/AllowedHeadersFilterTest.java
@@ -29,7 +29,7 @@ public class AllowedHeadersFilterTest {
   private static final List<String> TEST_HEADERS =
       Lists.newArrayList("Content-Type", "content-length", "Accept", "Location");
 
-  private StringToPatternFunction patternGenerator = new StringToPatternFunction();
+  private StringToPatternFunction patternGenerator = StringToPatternFunction.getInstance();
 
   @Test
   public void whenNoAllowedHeadersAvailable_expectNoHeadersPassed() {

--- a/knotx-core/src/test/java/io/knotx/http/StringToPatternFunctionTest.java
+++ b/knotx-core/src/test/java/io/knotx/http/StringToPatternFunctionTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2018 Piotr Andruszkiewicz
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.knotx.http;
 
 import org.junit.BeforeClass;
@@ -30,33 +45,56 @@ public class StringToPatternFunctionTest {
     assertTrue(matches("foo*", "foobar"));
     assertTrue(matches("*foo", "barfoo"));
     assertTrue(matches("foo*bar", "foobazbar"));
+
+    assertTrue(matches("f**", "foo"));
+    assertTrue(matches("***", "foo"));
+    assertTrue(matches("foo*foo*", "foobarfoobar"));
+    assertTrue(matches("*foo*foo", "barfoobarfoo"));
   }
 
   @Test
   public void whenTextDoesNotMatchStringPattern_thenTextDoesNotMatchRegexPattern() {
-    assertFalse(matches("foo","bar"));
+    assertFalse(matches("foo", "bar"));
 
-    assertFalse(matches("","bar"));
-    assertFalse(matches("*",""));
+    assertFalse(matches("", "bar"));
+    assertFalse(matches("*", ""));
+    assertFalse(matches("**", "f"));
 
-    assertFalse(matches("foo*","foo"));
-    assertFalse(matches("*foo","foo"));
-    assertFalse(matches("foo*bar","foobar"));
+    assertFalse(matches("foo*", "foo"));
+    assertFalse(matches("*foo", "foo"));
+    assertFalse(matches("foo*bar", "foobar"));
 
-    //TODO The class should escape regexp constructs
-    //assertFalse(matches(".","a"));
-    //assertFalse(matches("[a-z]","a"));
-    //assertFalse(matches("\\d","1"));
-    //assertFalse(matches("$", ""));
-    //assertFalse(matches("^", ""));
-    //assertFalse(matches("a+", "aaa"));
-    //assertFalse(matches("a?", "a"));
-    //assertFalse(matches("a?", ""));
-    //assertFalse(matches("a{3}", "aaa"));
-    //assertFalse(matches("a|b", "a"));
-    //assertFalse(matches("a|b", "b"));
-    //assertFalse(matches("b(ar|az)", "bar"));
-    //assertFalse(matches("b(ar|az)", "baz"));
+    assertFalse(matches("foo*bar", "foobar"));
+    assertFalse(matches("foo**bar", "foobar"));
+    assertFalse(matches("foo**bar", "fooabar"));
+  }
+
+  @Test
+  public void whenStringPatternContainsRegexConstructs_thenTheyShouldBeEscaped() {
+    assertFalse(matches(".","a"));
+    assertFalse(matches("[a-z]","a"));
+    assertFalse(matches("\\d","1"));
+    assertFalse(matches("$", ""));
+    assertFalse(matches("^", ""));
+    assertFalse(matches("a+", "aaa"));
+    assertFalse(matches("a?", "a"));
+    assertFalse(matches("a?", ""));
+    assertFalse(matches("a{3}", "aaa"));
+    assertFalse(matches("a|b", "a"));
+    assertFalse(matches("a|b", "b"));
+    assertFalse(matches("b(ar|az)", "bar"));
+    assertFalse(matches("b(ar|az)", "baz"));
+
+    assertTrue(matches(".","."));
+    assertTrue(matches("[a-z]","[a-z]"));
+    assertTrue(matches("\\d","\\d"));
+    assertTrue(matches("$", "$"));
+    assertTrue(matches("^", "^"));
+    assertTrue(matches("a+", "a+"));
+    assertTrue(matches("a?", "a?"));
+    assertTrue(matches("a{3}", "a{3}"));
+    assertTrue(matches("a|b", "a|b"));
+    assertTrue(matches("b(ar|az)", "b(ar|az)"));
   }
 
   private boolean matches(String pattern, String text) {

--- a/knotx-core/src/test/java/io/knotx/http/StringToPatternFunctionTest.java
+++ b/knotx-core/src/test/java/io/knotx/http/StringToPatternFunctionTest.java
@@ -29,7 +29,7 @@ public class StringToPatternFunctionTest {
 
   @BeforeClass
   public static void setUp() {
-    stringToPattern = new StringToPatternFunction();
+    stringToPattern = StringToPatternFunction.getInstance();
   }
 
   @Test

--- a/knotx-core/src/test/java/io/knotx/http/StringToPatternFunctionTest.java
+++ b/knotx-core/src/test/java/io/knotx/http/StringToPatternFunctionTest.java
@@ -33,32 +33,47 @@ public class StringToPatternFunctionTest {
   }
 
   @Test
-  public void whenTextMatchesStringPattern_thenTextMatchesRegexPattern() {
+  public void whenPatternHasNoConstructs_thenTextIsMatchedExactly() {
     assertTrue(matches("foo", "foo"));
+
+    assertFalse(matches("foo", "bar"));
+  }
+
+  @Test
+  public void whenPatternIsMixedCased_thenTextIsMatchedCaseInsensitive() {
     assertTrue(matches("foo", "FOO"));
     assertTrue(matches("foo", "Foo"));
     assertTrue(matches("foo", "fOO"));
+    assertTrue(matches("FOO", "foo"));
+    assertTrue(matches("Foo", "foo"));
+    assertTrue(matches("fOO", "foo"));
+  }
 
+  @Test
+  public void whenPatternIsEmptyString_thenOnlyEmptyTextMatches() {
     assertTrue(matches("", ""));
-    assertTrue(matches("*", "foo"));
 
+    assertFalse(matches("", "bar"));
+  }
+
+  @Test
+  public void whenPatternContainsOnlyNWildcardSymbols_thenTextMustBeAtLeastNCharactersLong() {
+    assertTrue(matches("*", "foo"));
+    assertTrue(matches("***", "foo"));
+
+    assertFalse(matches("*", ""));
+    assertFalse(matches("**", "f"));
+  }
+
+  @Test
+  public void whenPatternContainsWildcardSymbols_thenTextIsMatchedAccordingToWildcardDefinition() {
     assertTrue(matches("foo*", "foobar"));
     assertTrue(matches("*foo", "barfoo"));
     assertTrue(matches("foo*bar", "foobazbar"));
 
     assertTrue(matches("f**", "foo"));
-    assertTrue(matches("***", "foo"));
     assertTrue(matches("foo*foo*", "foobarfoobar"));
     assertTrue(matches("*foo*foo", "barfoobarfoo"));
-  }
-
-  @Test
-  public void whenTextDoesNotMatchStringPattern_thenTextDoesNotMatchRegexPattern() {
-    assertFalse(matches("foo", "bar"));
-
-    assertFalse(matches("", "bar"));
-    assertFalse(matches("*", ""));
-    assertFalse(matches("**", "f"));
 
     assertFalse(matches("foo*", "foo"));
     assertFalse(matches("*foo", "foo"));
@@ -70,31 +85,33 @@ public class StringToPatternFunctionTest {
   }
 
   @Test
-  public void whenStringPatternContainsRegexConstructs_thenTheyShouldBeEscaped() {
-    assertFalse(matches(".","a"));
-    assertFalse(matches("[a-z]","a"));
-    assertFalse(matches("\\d","1"));
-    assertFalse(matches("$", ""));
-    assertFalse(matches("^", ""));
-    assertFalse(matches("a+", "aaa"));
-    assertFalse(matches("a?", "a"));
-    assertFalse(matches("a?", ""));
-    assertFalse(matches("a{3}", "aaa"));
-    assertFalse(matches("a|b", "a"));
-    assertFalse(matches("a|b", "b"));
-    assertFalse(matches("b(ar|az)", "bar"));
-    assertFalse(matches("b(ar|az)", "baz"));
+  public void whenPatternContainsRegexConstructs_thenTheyShouldBeMatched() {
+    assertTrue(matches(".", "a"));
+    assertTrue(matches("[a-z]", "a"));
+    assertTrue(matches("\\d", "1"));
+    assertTrue(matches("$", ""));
+    assertTrue(matches("^", ""));
+    assertTrue(matches("a+", "aaa"));
+    assertTrue(matches("a?", "a"));
+    assertTrue(matches("a?", ""));
+    assertTrue(matches("a{3}", "aaa"));
+    assertTrue(matches("a|b", "a"));
+    assertTrue(matches("a|b", "b"));
+    assertTrue(matches("b(ar|az)", "bar"));
+    assertTrue(matches("b(ar|az)", "baz"));
+  }
 
-    assertTrue(matches(".","."));
-    assertTrue(matches("[a-z]","[a-z]"));
-    assertTrue(matches("\\d","\\d"));
-    assertTrue(matches("$", "$"));
-    assertTrue(matches("^", "^"));
-    assertTrue(matches("a+", "a+"));
-    assertTrue(matches("a?", "a?"));
-    assertTrue(matches("a{3}", "a{3}"));
-    assertTrue(matches("a|b", "a|b"));
-    assertTrue(matches("b(ar|az)", "b(ar|az)"));
+  @Test
+  public void whenPatternContainsRegexConstructs_thenTheyShouldNotBeEscaped() {
+    assertFalse(matches("[a-z]", "[a-z]"));
+    assertFalse(matches("\\d", "\\d"));
+    assertFalse(matches("$", "$"));
+    assertFalse(matches("^", "^"));
+    assertFalse(matches("a+", "a+"));
+    assertFalse(matches("a?", "a?"));
+    assertFalse(matches("a{3}", "a{3}"));
+    assertFalse(matches("a|b", "a|b"));
+    assertFalse(matches("b(ar|az)", "b(ar|az)"));
   }
 
   private boolean matches(String pattern, String text) {

--- a/knotx-core/src/test/java/io/knotx/http/StringToPatternFunctionTest.java
+++ b/knotx-core/src/test/java/io/knotx/http/StringToPatternFunctionTest.java
@@ -1,0 +1,67 @@
+package io.knotx.http;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static org.junit.Assert.*;
+
+public class StringToPatternFunctionTest {
+
+  private static StringToPatternFunction stringToPattern;
+
+  @BeforeClass
+  public static void setUp() {
+    stringToPattern = new StringToPatternFunction();
+  }
+
+  @Test
+  public void whenTextMatchesStringPattern_thenTextMatchesRegexPattern() {
+    assertTrue(matches("foo", "foo"));
+    assertTrue(matches("foo", "FOO"));
+    assertTrue(matches("foo", "Foo"));
+    assertTrue(matches("foo", "fOO"));
+
+    assertTrue(matches("", ""));
+    assertTrue(matches("*", "foo"));
+
+    assertTrue(matches("foo*", "foobar"));
+    assertTrue(matches("*foo", "barfoo"));
+    assertTrue(matches("foo*bar", "foobazbar"));
+  }
+
+  @Test
+  public void whenTextDoesNotMatchStringPattern_thenTextDoesNotMatchRegexPattern() {
+    assertFalse(matches("foo","bar"));
+
+    assertFalse(matches("","bar"));
+    assertFalse(matches("*",""));
+
+    assertFalse(matches("foo*","foo"));
+    assertFalse(matches("*foo","foo"));
+    assertFalse(matches("foo*bar","foobar"));
+
+    //TODO The class should escape regexp constructs
+    //assertFalse(matches(".","a"));
+    //assertFalse(matches("[a-z]","a"));
+    //assertFalse(matches("\\d","1"));
+    //assertFalse(matches("$", ""));
+    //assertFalse(matches("^", ""));
+    //assertFalse(matches("a+", "aaa"));
+    //assertFalse(matches("a?", "a"));
+    //assertFalse(matches("a?", ""));
+    //assertFalse(matches("a{3}", "aaa"));
+    //assertFalse(matches("a|b", "a"));
+    //assertFalse(matches("a|b", "b"));
+    //assertFalse(matches("b(ar|az)", "bar"));
+    //assertFalse(matches("b(ar|az)", "baz"));
+  }
+
+  private boolean matches(String pattern, String text) {
+    Pattern regexPattern = stringToPattern.apply(pattern);
+    Matcher matcher = regexPattern.matcher(text);
+    return matcher.matches();
+  }
+}

--- a/knotx-knot/knotx-knot-action/src/main/java/io/knotx/knot/action/ActionKnotConfiguration.java
+++ b/knotx-knot/knotx-knot-action/src/main/java/io/knotx/knot/action/ActionKnotConfiguration.java
@@ -50,12 +50,12 @@ public class ActionKnotConfiguration {
           metadata.allowedRequestHeaders = item
               .getJsonArray("allowedRequestHeaders", new JsonArray()).stream()
               .map(object -> (String) object)
-              .map(new StringToPatternFunction())
+              .map(StringToPatternFunction.getInstance())
               .collect(Collectors.toList());
           metadata.allowedResponseHeaders = item
               .getJsonArray("allowedResponseHeaders", new JsonArray()).stream()
               .map(object -> (String) object)
-              .map(new StringToPatternFunction())
+              .map(StringToPatternFunction.getInstance())
               .collect(Collectors.toList());
           return metadata;
         }).collect(Collectors.toList());

--- a/knotx-repository-connector/knotx-repository-connector-http/src/main/java/io/knotx/repository/impl/HttpRepositoryConnectorProxyImpl.java
+++ b/knotx-repository-connector/knotx-repository-connector-http/src/main/java/io/knotx/repository/impl/HttpRepositoryConnectorProxyImpl.java
@@ -69,7 +69,7 @@ public class HttpRepositoryConnectorProxyImpl implements RepositoryConnectorProx
     allowedRequestHeaders = configuration.getJsonArray("allowedRequestHeaders", new JsonArray())
         .stream()
         .map(object -> (String) object)
-        .map(new StringToPatternFunction())
+        .map(StringToPatternFunction.getInstance())
         .collect(Collectors.toList());
     httpClient = createHttpClient(vertx);
   }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
The StringToPatternFunction was cleaned a bit. Now it has it's own unit tests. The pattern now includes escaping of regex constructs, so only "*" works.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
I'm trying to work my way inside-out to get familiar with the project. This class seemed like a good start. 

I noticed that user could pass some regex constructs to it and they would be included in the resulting pattern, so I added escape characters.

I'm not sure if it's intended, but the "*" wildcard does not work as I was expecting - it matches at least one character. Is that correct?
<!--- If it fixes an open issue, please link to the issue here. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code style](https://github.com/Cognifide/knotx/blob/master/CONTRIBUTING.md#coding-conventions) of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

---
I hereby agree to the terms of the Knot.x Contributor License Agreement.
