### PR TITLE
Bugfix/annotation processor

### DIFF
--- a/knotx-core/pom.xml
+++ b/knotx-core/pom.xml
@@ -62,6 +62,7 @@
       <groupId>io.vertx</groupId>
       <artifactId>vertx-service-proxy</artifactId>
       <classifier>processor</classifier>
+      <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>io.vertx</groupId>


### PR DESCRIPTION
vertx-service-proxy-3.5.1-processor.jar declared as a mandatory dependency causes javac in the projects dependent on knotx-core doesn't compile java classes.