### PR TITLE
Fixed header matching to be case insensitive

### DIFF
--- a/knotx-adapter/knotx-adapter-common/src/main/java/io/knotx/adapter/common/configuration/ServiceSettings.java
+++ b/knotx-adapter/knotx-adapter-common/src/main/java/io/knotx/adapter/common/configuration/ServiceSettings.java
@@ -73,7 +73,7 @@ public class ServiceSettings {
     ServiceSettingsConverter.fromJson(json, this);
     if (allowedRequestHeaders != null) {
       allowedRequestHeadersPatterns = allowedRequestHeaders.stream()
-          .map(expr -> Pattern.compile(expr)).collect(Collectors.toList());
+          .map(expr -> Pattern.compile(expr, Pattern.CASE_INSENSITIVE)).collect(Collectors.toList());
     }
   }
 
@@ -149,7 +149,7 @@ public class ServiceSettings {
   public ServiceSettings setAllowedRequestHeaders(Set<String> allowedRequestHeaders) {
     this.allowedRequestHeaders = allowedRequestHeaders;
     allowedRequestHeadersPatterns = allowedRequestHeaders.stream()
-        .map(expr -> Pattern.compile(expr)).collect(Collectors.toList());
+        .map(expr -> Pattern.compile(expr, Pattern.CASE_INSENSITIVE)).collect(Collectors.toList());
     return this;
   }
 

--- a/knotx-core/src/main/java/io/knotx/repository/http/HttpRepositoryOptions.java
+++ b/knotx-core/src/main/java/io/knotx/repository/http/HttpRepositoryOptions.java
@@ -77,7 +77,7 @@ public class HttpRepositoryOptions {
     HttpRepositoryOptionsConverter.fromJson(json, this);
     if (allowedRequestHeaders != null) {
       allowedRequestHeaderPatterns = allowedRequestHeaders.stream()
-          .map(expr -> Pattern.compile(expr)).collect(Collectors.toList());
+          .map(expr -> Pattern.compile(expr, Pattern.CASE_INSENSITIVE)).collect(Collectors.toList());
     }
   }
 


### PR DESCRIPTION

## Description
The `allowedRequestHeaders` configurations that were using regexp to express which ones to allow where case sensitive. However, since the headers in HTTP are case insensitive we need to handle it the same way

## Motivation and Context
Make header matching case insensitive 

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code style](https://github.com/Cognifide/knotx/blob/master/CONTRIBUTING.md#coding-conventions) of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

---
I hereby agree to the terms of the Knot.x Contributor License Agreement.
