### PR TITLE
Custom handlebars delimiters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ All notable changes to Knot.x will be documented in this file.
 
 ## Unreleased
 List of changes that are finished but not yet released in any final version.
+ - [PR-422](https://github.com/Cognifide/knotx/pull/422) - Configurable Handlebars delimiters
 
 ## 1.3.0
  - [PR-376](https://github.com/Cognifide/knotx/pull/376) - Knot.x configurations refactor - Changed the way how configurations and it's defaults are build.

--- a/documentation/src/main/cheatsheet/cheatsheets.adoc
+++ b/documentation/src/main/cheatsheet/cheatsheets.adoc
@@ -644,6 +644,8 @@ Set the algorithm used to build a hash from the handlebars snippet.
 +++
 Set the size of the cache. After reaching the max size, new elements will replace the oldest one.
 +++
+|[[endDelimiter]]`endDelimiter`|`String`|-
+|[[startDelimiter]]`startDelimiter`|`String`|-
 |===
 [[ActionKnotOptions]]
 == ActionKnotOptions

--- a/documentation/src/main/wiki/HandlebarsKnot.md
+++ b/documentation/src/main/wiki/HandlebarsKnot.md
@@ -49,9 +49,10 @@ Handlebars Knot uses data from Fragment Context and applies it to Fragment Conte
 Finally Fragment Content is replaced with merged result.
 
 ## Interpolation symbol
-By default Handlebars engine uses `{{` and `}}` symbols as delimiters of variables, expressions, etc.
-However, since the Knot.x can be used to generate markup on server side, it might also consists of markup to be interpreted by the front end engine, such as Angular.
-To avoid conflicts between mustache script to be executed server side from the client side, a Handlebars knot introduces two configuration parameters that enables you to configure custom symbols to be used in Knot.x snippets.
+By default , the Handlebars engine uses `{{` and `}}` symbols as tag delimiters.
+However, while Knot.x can be used to generate markup on the server side, the very same page might also contain templates intended for client-side processing. 
+This is often the case when frameworks like Angular.js or Vue.js are used.
+To avoid conflicts between Mustache templates to be executed server-side and ones evaluated on the client side, a Handlebars knot introduces two configuration parameters that enable you to configure custom symbols to be used in Knot.x snippets.
 E.g.:
 In order to use different symbols as below
 ```html

--- a/documentation/src/main/wiki/HandlebarsKnot.md
+++ b/documentation/src/main/wiki/HandlebarsKnot.md
@@ -48,6 +48,25 @@ Handlebars Knot uses data from Fragment Context and applies it to Fragment Conte
 ```
 Finally Fragment Content is replaced with merged result.
 
+## Interpolation symbol
+By default Handlebars engine uses `{{` and `}}` symbols as delimiters of variables, expressions, etc.
+However, since the Knot.x can be used to generate markup on server side, it might also consists of markup to be interpreted by the front end engine, such as Angular.
+To avoid conflicts between mustache script to be executed server side from the client side, a Handlebars knot introduces two configuration parameters that enables you to configure custom symbols to be used in Knot.x snippets.
+E.g.:
+In order to use different symbols as below
+```html
+<div class="col-md-4">
+  <h2>Snippet1 - {<_result.message>}</h2>
+</div>
+```
+You can reconfigure an engine as follows in the Handlebars Knot section:
+```hocon
+config {
+  startDelimiter = "{<"
+  endDelimiter = ">}"
+}
+```
+
 ## How to configure?
 For all configuration fields and their defaults consult [HandlebarsKnotOptions](https://github.com/Cognifide/knotx/blob/master/documentation/src/main/cheatsheet/cheatsheets.adoc#handlebarsknotoptions)
 

--- a/knotx-it-tests/src/test/java/io/knotx/example/monolith/SampleApplicationIT.java
+++ b/knotx-it-tests/src/test/java/io/knotx/example/monolith/SampleApplicationIT.java
@@ -84,6 +84,12 @@ public class SampleApplicationIT {
   }
 
   @Test
+  @KnotxConfiguration("knotx-test-app-custom-symbol.json")
+  public void whenRequestingLocalSimplePageWithGetCustomSymbol_expectLocalSimpleHtml(TestContext context) {
+    testGetRequest(context, "/content/local/customSymbol.html", "localSimpleResult.html");
+  }
+
+  @Test
   @KnotxConfiguration("knotx-test-app-no-body.json")
   public void whenRequestingLocalPageWhereInServiceIsMissingResponseBody_expectNoBodyHtml(
       TestContext context) {

--- a/knotx-it-tests/src/test/java/io/knotx/example/monolith/SampleApplicationIT.java
+++ b/knotx-it-tests/src/test/java/io/knotx/example/monolith/SampleApplicationIT.java
@@ -85,8 +85,17 @@ public class SampleApplicationIT {
 
   @Test
   @KnotxConfiguration("knotx-test-app-custom-symbol.json")
-  public void whenRequestingLocalSimplePageWithGetCustomSymbol_expectLocalSimpleHtml(TestContext context) {
+  public void whenRequestingLocalSimplePageWithGetCustomSymbol_expectLocalSimpleHtml(
+      TestContext context) {
     testGetRequest(context, "/content/local/customSymbol.html", "localSimpleResult.html");
+  }
+
+  @Test
+  @KnotxConfiguration("knotx-test-app-custom-and-default-symbol.json")
+  public void whenRequestingLocalSimplePageWithGetCustomAndDefaultSymbol_expectLocalSimpleHtmlWithDefault(
+      TestContext context) {
+    testGetRequest(context, "/content/local/customAndDefaultSymbol.html",
+        "localSimpleResultCustomAndDefault.html");
   }
 
   @Test

--- a/knotx-it-tests/src/test/java/io/knotx/example/monolith/SampleApplicationIT.java
+++ b/knotx-it-tests/src/test/java/io/knotx/example/monolith/SampleApplicationIT.java
@@ -87,7 +87,7 @@ public class SampleApplicationIT {
   @KnotxConfiguration("knotx-test-app-custom-symbol.json")
   public void whenRequestingLocalSimplePageWithGetCustomSymbol_expectLocalSimpleHtml(
       TestContext context) {
-    testGetRequest(context, "/content/local/customSymbol.html", "localSimpleResult.html");
+    testGetRequest(context, "/content/local/customSymbol.html", "localSimpleResultAngular.html");
   }
 
   @Test

--- a/knotx-it-tests/src/test/resources/content/local/customAndDefaultSymbol.html
+++ b/knotx-it-tests/src/test/resources/content/local/customAndDefaultSymbol.html
@@ -1,0 +1,103 @@
+<!--
+
+    Copyright (C) 2016 Cognifide Limited
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link rel="shortcut icon" href="http://cognifide.com/favicon.ico?v=2"/>
+  <title>Knot.x</title>
+  <link href="https://bootswatch.com/4/simplex/bootstrap.min.css" rel="stylesheet"/>
+</head>
+<body>
+<div class="container-fluid">
+  <div class="row">
+    <div class="col-md-12">
+      <div class="jumbotron">
+        <h2>
+          Hello Knot.x - reactive micro-service assembler world!
+        </h2>
+        <p>
+          This template is served from the <strong>local</strong> repository.
+        </p>
+        <p>
+          <a class="btn btn-primary btn-large"
+             href="https://github.com/Cognifide/knotx">Learn more</a>
+        </p>
+      </div>
+    </div>
+  </div>
+  <div class="row">
+    <script data-knotx-knots="services,handlebars"
+            data-knotx-service="first-service"
+            data-knotx-service-second="second-service"
+            data-knotx-service-third="third-service"
+            type="text/knotx-snippet">
+
+      <div class="col-md-4">
+        <h2>Snippet1 - {[_result.message]}</h2>
+        <div>Snippet1 - {[_result.body.a]}</div>
+        <div>{[#bold]}Custom Handlebars helper{[/bold]}</div>
+      </div>
+      <div class="col-md-4">
+        <h2>Snippet1 - {[second._result.message]}</h2>
+        <div>Snippet1 - {[second._result.body.a]}</div>
+        {[#string_equals second._response.statusCode "200"]}
+        <div>Success! Status code : {[second._response.statusCode]}</div>
+        {[/string_equals]}
+      </div>
+      <div class="col-md-4">
+        <h2>Snippet1 - {[third._result.message]}</h2>
+        <div>Snippet1 - {[third._result.body.a]}</div>
+      </div>
+    </script>
+  </div>
+  <div class="row">
+    <div class="col-md-4">
+      <script data-knotx-knots="services,handlebars" data-knotx-service="second-service"
+              type="text/knotx-snippet">
+        <h2>Snippet2 - {{_result.message}}</h2>
+        <p>Snippet2 - {{_result.body.a}}</p>
+        {{#string_equals _result.status "success"}}<p>Success!</p>{{/string_equals}}
+      </script>
+    </div>
+    <div class="col-md-4">
+      <script data-knotx-knots="services,handlebars" data-knotx-service="third-service"
+              type="text/knotx-snippet">
+        <h2>Snippet3 - {[_result.message]}</h2>
+        <p>Snippet3 - {[_result.body.a]}</p>
+      </script>
+    </div>
+    <div class="col-md-4">
+      <script data-knotx-knots="services,handlebars" data-knotx-service="third-service"
+              type="text/knotx-snippet">
+        <h2>Snippet4 - {[_result.message]}</h2>
+        <p>Snippet4 - {[encode_uri _result.url]}</p>
+      </script>
+    </div>
+  </div>
+</div>
+<script src="https://code.jquery.com/jquery-2.2.4.min.js"
+        integrity="sha256-BbhdlvQf/xTY9gja0Dq3HiwQF8LaCRTXxZKRutelT44="
+        crossorigin="anonymous"></script>
+<script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"
+        integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa"
+        crossorigin="anonymous"></script>
+</body>
+</html>

--- a/knotx-it-tests/src/test/resources/content/local/customSymbol.html
+++ b/knotx-it-tests/src/test/resources/content/local/customSymbol.html
@@ -1,0 +1,103 @@
+<!--
+
+    Copyright (C) 2016 Cognifide Limited
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link rel="shortcut icon" href="http://cognifide.com/favicon.ico?v=2"/>
+  <title>Knot.x</title>
+  <link href="https://bootswatch.com/4/simplex/bootstrap.min.css" rel="stylesheet"/>
+</head>
+<body>
+<div class="container-fluid">
+  <div class="row">
+    <div class="col-md-12">
+      <div class="jumbotron">
+        <h2>
+          Hello Knot.x - reactive micro-service assembler world!
+        </h2>
+        <p>
+          This template is served from the <strong>local</strong> repository.
+        </p>
+        <p>
+          <a class="btn btn-primary btn-large"
+             href="https://github.com/Cognifide/knotx">Learn more</a>
+        </p>
+      </div>
+    </div>
+  </div>
+  <div class="row">
+    <script data-knotx-knots="services,handlebars"
+            data-knotx-service="first-service"
+            data-knotx-service-second="second-service"
+            data-knotx-service-third="third-service"
+            type="text/knotx-snippet">
+
+      <div class="col-md-4">
+        <h2>Snippet1 - {[_result.message]}</h2>
+        <div>Snippet1 - {[_result.body.a]}</div>
+        <div>{[#bold]}Custom Handlebars helper{[/bold]}</div>
+      </div>
+      <div class="col-md-4">
+        <h2>Snippet1 - {[second._result.message]}</h2>
+        <div>Snippet1 - {[second._result.body.a]}</div>
+        {[#string_equals second._response.statusCode "200"]}
+        <div>Success! Status code : {[second._response.statusCode]}</div>
+        {[/string_equals]}
+      </div>
+      <div class="col-md-4">
+        <h2>Snippet1 - {[third._result.message]}</h2>
+        <div>Snippet1 - {[third._result.body.a]}</div>
+      </div>
+    </script>
+  </div>
+  <div class="row">
+    <div class="col-md-4">
+      <script data-knotx-knots="services,handlebars" data-knotx-service="second-service"
+              type="text/knotx-snippet">
+        <h2>Snippet2 - {[_result.message]}</h2>
+        <p>Snippet2 - {[_result.body.a]}</p>
+        {[#string_equals _result.status "success"]}<p>Success!</p>{[/string_equals]}
+      </script>
+    </div>
+    <div class="col-md-4">
+      <script data-knotx-knots="services,handlebars" data-knotx-service="third-service"
+              type="text/knotx-snippet">
+        <h2>Snippet3 - {[_result.message]}</h2>
+        <p>Snippet3 - {[_result.body.a]}</p>
+      </script>
+    </div>
+    <div class="col-md-4">
+      <script data-knotx-knots="services,handlebars" data-knotx-service="third-service"
+              type="text/knotx-snippet">
+        <h2>Snippet4 - {[_result.message]}</h2>
+        <p>Snippet4 - {[encode_uri _result.url]}</p>
+      </script>
+    </div>
+  </div>
+</div>
+<script src="https://code.jquery.com/jquery-2.2.4.min.js"
+        integrity="sha256-BbhdlvQf/xTY9gja0Dq3HiwQF8LaCRTXxZKRutelT44="
+        crossorigin="anonymous"></script>
+<script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"
+        integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa"
+        crossorigin="anonymous"></script>
+</body>
+</html>

--- a/knotx-it-tests/src/test/resources/knotx-test-app-custom-and-default-symbol.json
+++ b/knotx-it-tests/src/test/resources/knotx-test-app-custom-and-default-symbol.json
@@ -1,0 +1,308 @@
+{
+  "modules": [
+    "server=io.knotx.server.KnotxServerVerticle",
+    "httpRepo=io.knotx.repository.http.HttpRepositoryConnectorVerticle",
+    "fsRepo=io.knotx.repository.fs.FilesystemRepositoryConnectorVerticle",
+    "splitter=io.knotx.splitter.FragmentSplitterVerticle",
+    "assembler=io.knotx.assembler.FragmentAssemblerVerticle",
+    "hbsKnot=io.knotx.knot.templating.HandlebarsKnotVerticle",
+    "serviceKnot=io.knotx.knot.service.ServiceKnotVerticle",
+    "actionKnot=io.knotx.knot.action.ActionKnotVerticle",
+    "serviceAdapter=io.knotx.adapter.service.http.HttpServiceAdapterVerticle",
+    "mockRepo=io.knotx.mocks.MockRemoteRepositoryVerticle",
+    "mockService=io.knotx.mocks.MockServiceVerticle"
+  ],
+  "config": {
+    "server": {
+      "options": {
+        "config": {
+          "serverOptions": {
+            "port": 9092
+          },
+          "displayExceptionDetails": true,
+          "allowedResponseHeaders": [
+            "Access-Control-Allow-Origin",
+            "Content-Type",
+            "Content-Length"
+          ],
+          "defaultFlow": {
+            "repositories": [
+              {
+                "path": "/content/local/.*",
+                "address": "knotx.core.repository.filesystem"
+              },
+              {
+                "path": "/content/.*",
+                "address": "knotx.core.repository.http"
+              }
+            ],
+            "routing": {
+              "GET": {
+                "items": [
+                  {
+                    "path": ".*\\.html",
+                    "address": "knotx.knot.action",
+                    "onTransition": {
+                      "next": {
+                        "address": "knotx.knot.service",
+                        "onTransition": {
+                          "next": {
+                            "address": "knotx.knot.handlebars"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              },
+              "POST": {
+                "items": [
+                  {
+                    "path": ".*\\.html",
+                    "address": "knotx.knot.action",
+                    "onTransition": {
+                      "next": {
+                        "address": "knotx.knot.service",
+                        "onTransition": {
+                          "next": {
+                            "address": "knotx.knot.handlebars"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        }
+      }
+    },
+    "mockRepo": {
+      "options": {
+        "config": {
+          "mockDataRoot": "mock/repository",
+          "httpPort": 4001
+        }
+      }
+    },
+    "mockService": {
+      "options": {
+        "config": {
+          "mockDataRoot": "mock/service",
+          "bouncing": true,
+          "httpPort": 4000
+        }
+      }
+    },
+    "actionAdapter": {
+      "options": {
+        "config": {
+          "address": "mock.action.adapter",
+          "clientOptions": {
+            "maxPoolSize": 1000,
+            "keepAlive": false
+          },
+          "customRequestHeader": {
+            "name": "Server-User-Agent",
+            "value": "Knot.x"
+          },
+          "services": [
+            {
+              "path": "/service/mock/.*",
+              "scheme": "http",
+              "domain": "localhost",
+              "port": 4000,
+              "allowedRequestHeaders": [
+                "Content-Type",
+                "X-*"
+              ]
+            },
+            {
+              "scheme": "http",
+              "path": "/service/.*",
+              "domain": "localhost",
+              "port": 8080,
+              "allowedRequestHeaders": [
+                "Content-Type",
+                "X-*"
+              ]
+            }
+          ]
+        }
+      }
+    },
+    "actionKnot": {
+      "options": {
+        "config": {
+          "formIdentifierName": "_frmId",
+          "adapters": [
+            {
+              "name": "subscribe-competition",
+              "address": "mock.action.adapter",
+              "params": {
+                "path": "/service/mock/post-competition.json"
+              },
+              "allowedRequestHeaders": [
+                "Cookie"
+              ],
+              "allowedResponseHeaders": [
+                "Set-Cookie",
+                "Location"
+              ]
+            },
+            {
+              "name": "subscribe-newsletter",
+              "address": "mock.action.adapter",
+              "params": {
+                "path": "/service/mock/post-newsletter.json"
+              },
+              "allowedRequestHeaders": [
+                "Cookie"
+              ],
+              "allowedResponseHeaders": [
+                "Set-Cookie",
+                "Location"
+              ]
+            },
+            {
+              "name": "step1",
+              "address": "mock.action.adapter",
+              "params": {
+                "path": "/service/mock/post-step-1.json"
+              },
+              "allowedRequestHeaders": [
+                "Cookie",
+                "Content-Type",
+                "Content-Length"
+              ],
+              "allowedResponseHeaders": [
+                "Set-Cookie",
+                "Location"
+              ]
+            },
+            {
+              "name": "step2",
+              "address": "mock.action.adapter",
+              "params": {
+                "path": "/service/mock/post-step-2.json"
+              },
+              "allowedRequestHeaders": [
+                "Cookie",
+                "Content-Type",
+                "Content-Length"
+              ],
+              "allowedResponseHeaders": [
+                "Set-Cookie",
+                "Location"
+              ]
+            }
+          ]
+        }
+      }
+    },
+    "httpRepo": {
+      "options": {
+        "config": {
+          "clientDestination": {
+            "scheme": "http",
+            "domain": "localhost",
+            "port": 4001
+          }
+        }
+      }
+    },
+    "serviceKnot": {
+      "options": {
+        "config": {
+          "services": [
+            {
+              "name": "first-service",
+              "address": "knotx.adapter.service.http",
+              "params": {
+                "path": "/service/mock/first.json"
+              },
+              "cacheKey": "first"
+            },
+            {
+              "name": "second-service",
+              "address": "knotx.adapter.service.http",
+              "params": {
+                "path": "/service/mock/second.json"
+              }
+            },
+            {
+              "name": "third-service",
+              "address": "knotx.adapter.service.http",
+              "params": {
+                "path": "/service/mock/third.json"
+              }
+            },
+            {
+              "name": "labelsRepository",
+              "address": "knotx.adapter.service.http"
+            }
+          ]
+        }
+      }
+    },
+    "serviceAdapter": {
+      "options": {
+        "config": {
+          "services": [
+            {
+              "path": "/service/mock/.*",
+              "scheme": "http",
+              "domain": "localhost",
+              "port": 4000,
+              "allowedRequestHeaders": [
+                "Content-Type",
+                "X-*"
+              ]
+            },
+            {
+              "path": "/service/.*",
+              "scheme": "http",
+              "domain": "localhost",
+              "port": 8080,
+              "allowedRequestHeaders": [
+                "Content-Type",
+                "X-*"
+              ]
+            }
+          ]
+        }
+      }
+    },
+    "hbsKnot": {
+      "options": {
+        "config": {
+          "cacheSize": 1000,
+          "startDelimiter": "{[",
+          "endDelimiter": "]}"
+        }
+      }
+    },
+    "splitter": {
+      "options": {
+        "config": {
+          "snippetOptions": {
+            "tagName": "script",
+            "paramsPrefix": "data-knotx-"
+          }
+        }
+      }
+    },
+    "assembler": {
+      "options": {
+        "config": {
+          "snippetOptions": {
+            "tagName": "script",
+            "paramsPrefix": "data-knotx-"
+          }
+        }
+      }
+    }
+  }
+}
+

--- a/knotx-it-tests/src/test/resources/knotx-test-app-custom-symbol.json
+++ b/knotx-it-tests/src/test/resources/knotx-test-app-custom-symbol.json
@@ -1,0 +1,308 @@
+{
+  "modules": [
+    "server=io.knotx.server.KnotxServerVerticle",
+    "httpRepo=io.knotx.repository.http.HttpRepositoryConnectorVerticle",
+    "fsRepo=io.knotx.repository.fs.FilesystemRepositoryConnectorVerticle",
+    "splitter=io.knotx.splitter.FragmentSplitterVerticle",
+    "assembler=io.knotx.assembler.FragmentAssemblerVerticle",
+    "hbsKnot=io.knotx.knot.templating.HandlebarsKnotVerticle",
+    "serviceKnot=io.knotx.knot.service.ServiceKnotVerticle",
+    "actionKnot=io.knotx.knot.action.ActionKnotVerticle",
+    "serviceAdapter=io.knotx.adapter.service.http.HttpServiceAdapterVerticle",
+    "mockRepo=io.knotx.mocks.MockRemoteRepositoryVerticle",
+    "mockService=io.knotx.mocks.MockServiceVerticle"
+  ],
+  "config": {
+    "server": {
+      "options": {
+        "config": {
+          "serverOptions": {
+            "port": 9092
+          },
+          "displayExceptionDetails": true,
+          "allowedResponseHeaders": [
+            "Access-Control-Allow-Origin",
+            "Content-Type",
+            "Content-Length"
+          ],
+          "defaultFlow": {
+            "repositories": [
+              {
+                "path": "/content/local/.*",
+                "address": "knotx.core.repository.filesystem"
+              },
+              {
+                "path": "/content/.*",
+                "address": "knotx.core.repository.http"
+              }
+            ],
+            "routing": {
+              "GET": {
+                "items": [
+                  {
+                    "path": ".*\\.html",
+                    "address": "knotx.knot.action",
+                    "onTransition": {
+                      "next": {
+                        "address": "knotx.knot.service",
+                        "onTransition": {
+                          "next": {
+                            "address": "knotx.knot.handlebars"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              },
+              "POST": {
+                "items": [
+                  {
+                    "path": ".*\\.html",
+                    "address": "knotx.knot.action",
+                    "onTransition": {
+                      "next": {
+                        "address": "knotx.knot.service",
+                        "onTransition": {
+                          "next": {
+                            "address": "knotx.knot.handlebars"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        }
+      }
+    },
+    "mockRepo": {
+      "options": {
+        "config": {
+          "mockDataRoot": "mock/repository",
+          "httpPort": 4001
+        }
+      }
+    },
+    "mockService": {
+      "options": {
+        "config": {
+          "mockDataRoot": "mock/service",
+          "bouncing": true,
+          "httpPort": 4000
+        }
+      }
+    },
+    "actionAdapter": {
+      "options": {
+        "config": {
+          "address": "mock.action.adapter",
+          "clientOptions": {
+            "maxPoolSize": 1000,
+            "keepAlive": false
+          },
+          "customRequestHeader": {
+            "name": "Server-User-Agent",
+            "value": "Knot.x"
+          },
+          "services": [
+            {
+              "path": "/service/mock/.*",
+              "scheme": "http",
+              "domain": "localhost",
+              "port": 4000,
+              "allowedRequestHeaders": [
+                "Content-Type",
+                "X-*"
+              ]
+            },
+            {
+              "scheme": "http",
+              "path": "/service/.*",
+              "domain": "localhost",
+              "port": 8080,
+              "allowedRequestHeaders": [
+                "Content-Type",
+                "X-*"
+              ]
+            }
+          ]
+        }
+      }
+    },
+    "actionKnot": {
+      "options": {
+        "config": {
+          "formIdentifierName": "_frmId",
+          "adapters": [
+            {
+              "name": "subscribe-competition",
+              "address": "mock.action.adapter",
+              "params": {
+                "path": "/service/mock/post-competition.json"
+              },
+              "allowedRequestHeaders": [
+                "Cookie"
+              ],
+              "allowedResponseHeaders": [
+                "Set-Cookie",
+                "Location"
+              ]
+            },
+            {
+              "name": "subscribe-newsletter",
+              "address": "mock.action.adapter",
+              "params": {
+                "path": "/service/mock/post-newsletter.json"
+              },
+              "allowedRequestHeaders": [
+                "Cookie"
+              ],
+              "allowedResponseHeaders": [
+                "Set-Cookie",
+                "Location"
+              ]
+            },
+            {
+              "name": "step1",
+              "address": "mock.action.adapter",
+              "params": {
+                "path": "/service/mock/post-step-1.json"
+              },
+              "allowedRequestHeaders": [
+                "Cookie",
+                "Content-Type",
+                "Content-Length"
+              ],
+              "allowedResponseHeaders": [
+                "Set-Cookie",
+                "Location"
+              ]
+            },
+            {
+              "name": "step2",
+              "address": "mock.action.adapter",
+              "params": {
+                "path": "/service/mock/post-step-2.json"
+              },
+              "allowedRequestHeaders": [
+                "Cookie",
+                "Content-Type",
+                "Content-Length"
+              ],
+              "allowedResponseHeaders": [
+                "Set-Cookie",
+                "Location"
+              ]
+            }
+          ]
+        }
+      }
+    },
+    "httpRepo": {
+      "options": {
+        "config": {
+          "clientDestination": {
+            "scheme": "http",
+            "domain": "localhost",
+            "port": 4001
+          }
+        }
+      }
+    },
+    "serviceKnot": {
+      "options": {
+        "config": {
+          "services": [
+            {
+              "name": "first-service",
+              "address": "knotx.adapter.service.http",
+              "params": {
+                "path": "/service/mock/first.json"
+              },
+              "cacheKey": "first"
+            },
+            {
+              "name": "second-service",
+              "address": "knotx.adapter.service.http",
+              "params": {
+                "path": "/service/mock/second.json"
+              }
+            },
+            {
+              "name": "third-service",
+              "address": "knotx.adapter.service.http",
+              "params": {
+                "path": "/service/mock/third.json"
+              }
+            },
+            {
+              "name": "labelsRepository",
+              "address": "knotx.adapter.service.http"
+            }
+          ]
+        }
+      }
+    },
+    "serviceAdapter": {
+      "options": {
+        "config": {
+          "services": [
+            {
+              "path": "/service/mock/.*",
+              "scheme": "http",
+              "domain": "localhost",
+              "port": 4000,
+              "allowedRequestHeaders": [
+                "Content-Type",
+                "X-*"
+              ]
+            },
+            {
+              "path": "/service/.*",
+              "scheme": "http",
+              "domain": "localhost",
+              "port": 8080,
+              "allowedRequestHeaders": [
+                "Content-Type",
+                "X-*"
+              ]
+            }
+          ]
+        }
+      }
+    },
+    "hbsKnot": {
+      "options": {
+        "config": {
+          "cacheSize": 1000,
+          "startDelimiter": "{[",
+          "endDelimiter": "]}"
+        }
+      }
+    },
+    "splitter": {
+      "options": {
+        "config": {
+          "snippetOptions": {
+            "tagName": "script",
+            "paramsPrefix": "data-knotx-"
+          }
+        }
+      }
+    },
+    "assembler": {
+      "options": {
+        "config": {
+          "snippetOptions": {
+            "tagName": "script",
+            "paramsPrefix": "data-knotx-"
+          }
+        }
+      }
+    }
+  }
+}
+

--- a/knotx-it-tests/src/test/resources/localSimpleResultAngular.html
+++ b/knotx-it-tests/src/test/resources/localSimpleResultAngular.html
@@ -23,7 +23,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="shortcut icon" href="http://cognifide.com/favicon.ico?v=2"/>
   <title>Knot.x</title>
-  <link href="https://bootswatch.com/4/simplex/bootstrap.min.css" rel="stylesheet"/>
+  <link href="https://bootswatch.com/simplex/bootstrap.min.css" rel="stylesheet"/>
 </head>
 <body>
 <div class="container-fluid">
@@ -44,55 +44,40 @@
     </div>
   </div>
   <div class="row">
-    <script data-knotx-knots="services,handlebars"
-            data-knotx-service="first-service"
-            data-knotx-service-second="second-service"
-            data-knotx-service-third="third-service"
-            type="text/knotx-snippet">
 
-      <div class="col-md-4">
-        <h2>Snippet1 - {[_result.message]}</h2>
-        <div>Snippet1 - {[_result.body.a]}</div>
-        <div>{[#bold]}Custom Handlebars helper{[/bold]}</div>
-      </div>
-      <div class="col-md-4">
-        <h2>Snippet1 - {[second._result.message]}</h2>
-        <div>Snippet1 - {[second._result.body.a]}</div>
-        {[#string_equals second._response.statusCode "200"]}
-        <div>Success! Status code : {[second._response.statusCode]}</div>
-        {[/string_equals]}
-      </div>
-      <div class="col-md-4" ng-controller="HelloController">
-		    <h2>{{message}}</h2>
-      </div>
-      <div class="col-md-4">
-        <h2>Snippet1 - {[third._result.message]}</h2>
-        <div>Snippet1 - {[third._result.body.a]}</div>
-      </div>
-    </script>
+    <div class="col-md-4">
+      <h2>Snippet1 - this is webservice no. 1</h2>
+      <div>Snippet1 - message - a</div>
+      <div></div>
+    </div>
+    <div class="col-md-4">
+      <h2>Snippet1 - this is webservice no. 2</h2>
+      <div>Snippet1 - message - a</div>
+
+      <div>Success! Status code : 200</div>
+
+    </div>
+    <div class="col-md-4" ng-controller="HelloController">
+      <h2>{{message}}</h2>
+    </div>
+    <div class="col-md-4">
+      <h2>Snippet1 - this is webservice no. 3</h2>
+      <div>Snippet1 - message - a</div>
+    </div>
   </div>
   <div class="row">
     <div class="col-md-4">
-      <script data-knotx-knots="services,handlebars" data-knotx-service="second-service"
-              type="text/knotx-snippet">
-        <h2>Snippet2 - {[_result.message]}</h2>
-        <p>Snippet2 - {[_result.body.a]}</p>
-        {[#string_equals _result.status "success"]}<p>Success!</p>{[/string_equals]}
-      </script>
+      <h2>Snippet2 - this is webservice no. 2</h2>
+      <p>Snippet2 - message - a</p>
+      <p>Success!</p>
     </div>
     <div class="col-md-4">
-      <script data-knotx-knots="services,handlebars" data-knotx-service="third-service"
-              type="text/knotx-snippet">
-        <h2>Snippet3 - {[_result.message]}</h2>
-        <p>Snippet3 - {[_result.body.a]}</p>
-      </script>
+      <h2>Snippet3 - this is webservice no. 3</h2>
+      <p>Snippet3 - message - a</p>
     </div>
     <div class="col-md-4">
-      <script data-knotx-knots="services,handlebars" data-knotx-service="third-service"
-              type="text/knotx-snippet">
-        <h2>Snippet4 - {[_result.message]}</h2>
-        <p>Snippet4 - {[encode_uri _result.url]}</p>
-      </script>
+      <h2>Snippet4 - this is webservice no. 3</h2>
+      <p>Snippet4 - http%3A%2F%2Fexample.com</p>
     </div>
   </div>
 </div>

--- a/knotx-it-tests/src/test/resources/localSimpleResultCustomAndDefault.html
+++ b/knotx-it-tests/src/test/resources/localSimpleResultCustomAndDefault.html
@@ -1,0 +1,88 @@
+<!--
+
+    Copyright (C) 2016 Cognifide Limited
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link rel="shortcut icon" href="http://cognifide.com/favicon.ico?v=2"/>
+  <title>Knot.x</title>
+  <link href="https://bootswatch.com/simplex/bootstrap.min.css" rel="stylesheet"/>
+</head>
+<body>
+<div class="container-fluid">
+  <div class="row">
+    <div class="col-md-12">
+      <div class="jumbotron">
+        <h2>
+          Hello Knot.x - reactive micro-service assembler world!
+        </h2>
+        <p>
+          This template is served from the <strong>local</strong> repository.
+        </p>
+        <p>
+          <a class="btn btn-primary btn-large"
+             href="https://github.com/Cognifide/knotx">Learn more</a>
+        </p>
+      </div>
+    </div>
+  </div>
+  <div class="row">
+
+    <div class="col-md-4">
+      <h2>Snippet1 - this is webservice no. 1</h2>
+      <div>Snippet1 - message - a</div>
+      <div></div>
+    </div>
+    <div class="col-md-4">
+      <h2>Snippet1 - this is webservice no. 2</h2>
+      <div>Snippet1 - message - a</div>
+
+      <div>Success! Status code : 200</div>
+
+    </div>
+    <div class="col-md-4">
+      <h2>Snippet1 - this is webservice no. 3</h2>
+      <div>Snippet1 - message - a</div>
+    </div>
+  </div>
+  <div class="row">
+    <div class="col-md-4">
+      <h2>Snippet2 - {{_result.message}}</h2>
+      <p>Snippet2 - {{_result.body.a}}</p>
+      {{#string_equals _result.status "success"}}<p>Success!</p>{{/string_equals}}
+    </div>
+    <div class="col-md-4">
+      <h2>Snippet3 - this is webservice no. 3</h2>
+      <p>Snippet3 - message - a</p>
+    </div>
+    <div class="col-md-4">
+      <h2>Snippet4 - this is webservice no. 3</h2>
+      <p>Snippet4 - http%3A%2F%2Fexample.com</p>
+    </div>
+  </div>
+</div>
+<script src="https://code.jquery.com/jquery-2.2.4.min.js"
+        integrity="sha256-BbhdlvQf/xTY9gja0Dq3HiwQF8LaCRTXxZKRutelT44="
+        crossorigin="anonymous"></script>
+<script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"
+        integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa"
+        crossorigin="anonymous"></script>
+</body>
+</html>

--- a/knotx-knot/knotx-knot-handlebars/src/main/java/io/knotx/knot/templating/HandlebarsKnotOptions.java
+++ b/knotx-knot/knotx-knot-handlebars/src/main/java/io/knotx/knot/templating/HandlebarsKnotOptions.java
@@ -29,6 +29,10 @@ public class HandlebarsKnotOptions {
    */
   public final static String DEFAULT_CACHE_KEY_ALGORITHM = "MD5";
 
+  public final static String DEFAULT_START_DELIMITER = "{{";
+
+  public final static String DEFAULT_END_DELIMITER = "}}";
+
   /**
    * Default EB address of the verticle
    */
@@ -37,6 +41,8 @@ public class HandlebarsKnotOptions {
   private String address;
   private String cacheKeyAlgorithm;
   private Long cacheSize;
+  private String startDelimiter;
+  private String endDelimiter;
 
   /**
    * Default constructor
@@ -54,6 +60,8 @@ public class HandlebarsKnotOptions {
     this.address = other.address;
     this.cacheKeyAlgorithm = other.cacheKeyAlgorithm;
     this.cacheSize = other.cacheSize;
+    this.startDelimiter = other.startDelimiter;
+    this.endDelimiter = other.endDelimiter;
   }
 
   /**
@@ -80,6 +88,8 @@ public class HandlebarsKnotOptions {
   private void init() {
     address = DEFAULT_ADDRESS;
     cacheKeyAlgorithm = DEFAULT_CACHE_KEY_ALGORITHM;
+    startDelimiter = DEFAULT_START_DELIMITER;
+    endDelimiter = DEFAULT_END_DELIMITER;
   }
 
   /**
@@ -136,6 +146,24 @@ public class HandlebarsKnotOptions {
    */
   public HandlebarsKnotOptions setAddress(String address) {
     this.address = address;
+    return this;
+  }
+
+  public String getStartDelimiter() {
+    return startDelimiter;
+  }
+
+  public HandlebarsKnotOptions setStartDelimiter(String startDelimiter) {
+    this.startDelimiter = startDelimiter;
+    return this;
+  }
+
+  public String getEndDelimiter() {
+    return endDelimiter;
+  }
+
+  public HandlebarsKnotOptions setEndDelimiter(String endDelimiter) {
+    this.endDelimiter = endDelimiter;
     return this;
   }
 }

--- a/knotx-knot/knotx-knot-handlebars/src/main/java/io/knotx/knot/templating/impl/HandlebarsKnotProxyImpl.java
+++ b/knotx-knot/knotx-knot-handlebars/src/main/java/io/knotx/knot/templating/impl/HandlebarsKnotProxyImpl.java
@@ -59,7 +59,7 @@ public class HandlebarsKnotProxyImpl extends AbstractKnotProxy {
   private MessageDigest digest;
 
   public HandlebarsKnotProxyImpl(HandlebarsKnotOptions options) {
-    this.handlebars = createHandlebars();
+    this.handlebars = createHandlebars(options);
     this.cache = CacheBuilder.newBuilder()
         .maximumSize(options.getCacheSize())
         .removalListener(listener -> LOGGER.warn(
@@ -146,8 +146,10 @@ public class HandlebarsKnotProxyImpl extends AbstractKnotProxy {
     return new String(cacheKeyBytes);
   }
 
-  private Handlebars createHandlebars() {
+  private Handlebars createHandlebars(HandlebarsKnotOptions options) {
     Handlebars newHandlebars = new Handlebars();
+    newHandlebars.setStartDelimiter(options.getStartDelimiter());
+    newHandlebars.setEndDelimiter(options.getEndDelimiter());
     DefaultHandlebarsHelpers.registerFor(newHandlebars);
 
     ServiceLoader.load(CustomHandlebarsHelper.class)


### PR DESCRIPTION

## Description
There are use cases in which the template to be rendered by Knot.x consists of handlebars scripts that are to be interpreted client side e.g. using Angular. In order to do so, an Angular variables, expressions must not be processed by the Knot.x.
In order to enable this, there is a need to have Handlebars delimiters configured so, the developer might chose to use `[<` and `]>' delimiters instead of `{{` and `}}`

## Motivation and Context
- To split the HBS script between server-side and client side

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code style](https://github.com/Cognifide/knotx/blob/master/CONTRIBUTING.md#coding-conventions) of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.

---
I hereby agree to the terms of the Knot.x Contributor License Agreement.
