### PR TITLE
static fragment data passed to handlebars context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ All notable changes to Knot.x will be documented in this file.
 
 ## Unreleased
 List of changes that are finished but not yet released in any final version.
+ - [PR-426](https://github.com/Cognifide/knotx/pull/426) - Support constant data in handlebars fragments (https://github.com/Cognifide/knotx/issues/391)
 
 ## 1.3.0
  - [PR-376](https://github.com/Cognifide/knotx/pull/376) - Knot.x configurations refactor - Changed the way how configurations and it's defaults are build.

--- a/documentation/src/main/wiki/HandlebarsKnot.md
+++ b/documentation/src/main/wiki/HandlebarsKnot.md
@@ -70,10 +70,10 @@ config {
 
 ## Constant data
 You can add constant data attributes to snippet definition. Constant attributes are identified by `const-` prefix.
-Handlebars engine can access these values with prefix `_const`. Eg: data attribute `data-const-foo` can be referenced from handlebars as `{{_const.foo}}`
+Handlebars engine can access these values with prefix `_const`. Eg: data attribute `const-foo` can be referenced from handlebars as `{{_const.foo}}`.
 ```snippet
 <script
-  data-const-foo="foo value"
+  const-foo="foo value"
   type="text/knotx-snippet">
     <h2>{{_const.foo}}</h2>
  </script>
@@ -82,6 +82,7 @@ Rendered as:
 ```html
     <h2>foo value</h2>
 ```
+Note: you may prefix the data attribute key with `${SNIPPET_PARAMS_PREFIX}`
 
 
 ## How to configure?

--- a/documentation/src/main/wiki/HandlebarsKnot.md
+++ b/documentation/src/main/wiki/HandlebarsKnot.md
@@ -68,6 +68,22 @@ config {
 }
 ```
 
+## Constant data
+You can add constant data attributes to snippet definition. Constant attributes are identified by `const-` prefix.
+Handlebars engine can access these values with prefix `_const`. Eg: data attribute `data-const-foo` can be referenced from handlebars as `{{_const.foo}}`
+```snippet
+<script
+  data-const-foo="foo value"
+  type="text/knotx-snippet">
+    <h2>{{_const.foo}}</h2>
+ </script>
+```
+Rendered as:
+```html
+    <h2>foo value</h2>
+```
+
+
 ## How to configure?
 For all configuration fields and their defaults consult [HandlebarsKnotOptions](https://github.com/Cognifide/knotx/blob/master/documentation/src/main/cheatsheet/cheatsheets.adoc#handlebarsknotoptions)
 

--- a/documentation/src/main/wiki/UpgradeNotes.md
+++ b/documentation/src/main/wiki/UpgradeNotes.md
@@ -6,8 +6,19 @@ versions. You may see all changes in the [Changelog](https://github.com/Cognifid
 
 ## Master
 
-## Version 1.3.0
 List of changes that are finished but not yet released in any final version.
+ - [PR-426](https://github.com/Cognifide/knotx/pull/426) Support constant data in handlebars fragments. 
+   - You can add constant data attributes to snippet definition.  Items prefixed with `data-const-` are now passed into `FragmentContext`. 
+   - Handlebars can access constant data using prefix `_const`. Eg: data attribute `data-const-foo` can be referenced from handlebars as `{{_const.foo}}`
+   ```<script
+    data-const-foo="foo value"
+    type="text/knotx-snippet">
+      <h2>{{_const.foo}}</h2>
+    </script>
+   ```
+
+
+## Version 1.3.0
  - [PR-376](https://github.com/Cognifide/knotx/pull/376) and [PR-397](https://github.com/Cognifide/knotx/pull/397) - Configuration changes:
    - Multiple configuration files format is supported (with favouring the [HOCON](https://github.com/lightbend/config/blob/master/HOCON.md) and supporting nested configurations (includes). **Don't worry, your old `JSON` configurations are still supported!**
    - Removed module descriptors - all module configuration is now defined in the `conf` (written in [HOCON](https://github.com/lightbend/config/blob/master/HOCON.md)) files with proper comments and explanations.

--- a/documentation/src/main/wiki/UpgradeNotes.md
+++ b/documentation/src/main/wiki/UpgradeNotes.md
@@ -8,10 +8,10 @@ versions. You may see all changes in the [Changelog](https://github.com/Cognifid
 
 List of changes that are finished but not yet released in any final version.
  - [PR-426](https://github.com/Cognifide/knotx/pull/426) Support constant data in handlebars fragments. 
-   - You can add constant data attributes to snippet definition.  Items prefixed with `data-const-` are now passed into `FragmentContext`. 
-   - Handlebars can access constant data using prefix `_const`. Eg: data attribute `data-const-foo` can be referenced from handlebars as `{{_const.foo}}`
+   - You can add constant data attributes to snippet definition.  Items prefixed with `const-` are now passed into `FragmentContext`. 
+   - Handlebars can access constant data using prefix `_const`. Eg: data attribute `const-foo` can be referenced from handlebars as `{{_const.foo}}`
    ```<script
-    data-const-foo="foo value"
+    const-foo="foo value"
     type="text/knotx-snippet">
       <h2>{{_const.foo}}</h2>
     </script>

--- a/knotx-core/src/test/java/io/knotx/junit/coercers/KnotxCoercers.java
+++ b/knotx-core/src/test/java/io/knotx/junit/coercers/KnotxCoercers.java
@@ -57,8 +57,10 @@ public class KnotxCoercers {
     final String fragmentContent = FileReader.readText(fragmentContentFile);
     final String snippetParamPrefix = extractSnippetParamPrefix(params, fragmentParameters);
     final SnippetPatterns patterns = new SnippetPatterns(buildOptions(snippetTagName, snippetParamPrefix));
+    final JsonObject context = new JsonObject();
 
     Fragment fragmentMock = Mockito.mock(Fragment.class);
+    when(fragmentMock.context()).thenReturn(context);
     when(fragmentMock.content()).thenReturn(fragmentContent);
     when(fragmentMock.isRaw())
         .thenReturn(!patterns.getAnySnippetPattern().matcher(fragmentContent).matches());

--- a/knotx-knot/knotx-knot-service/src/main/java/io/knotx/knot/service/impl/FragmentContext.java
+++ b/knotx-knot/knotx-knot-service/src/main/java/io/knotx/knot/service/impl/FragmentContext.java
@@ -37,7 +37,7 @@ class FragmentContext {
 
   private static final String DATA_SERVICE = ".*service.*";
   private static final String DATA_PARAMS = ".*params.*";
-  private static final String DATA_CONSTANTS = "data-const-.*";
+  private static final String DATA_CONSTANTS = ".*const.*";
 
   private Fragment fragment;
   List<ServiceEntry> services;
@@ -88,7 +88,7 @@ class FragmentContext {
   }
 
   private static String getConstId(Attribute in) {
-	  return StringUtils.removeStart(in.getKey(), "data-const-");
+	  return StringUtils.substringAfter(in.getKey(), "const-");
   }
 
   /**

--- a/knotx-knot/knotx-knot-service/src/test/java/io/knotx/knot/service/impl/FragmentContextTest.java
+++ b/knotx-knot/knotx-knot-service/src/test/java/io/knotx/knot/service/impl/FragmentContextTest.java
@@ -78,5 +78,17 @@ public class FragmentContextTest {
         )
     );
   }
+  
+  @TestWith({
+      "snippet_one_const.txt;{\"const1\":\"const1 value\"}",
+      "snippet_two_consts.txt;{\"const1\":\"const1 value\",\"const2\":\"const2 value\"}",
+  })
+  public void from_whenFragmentContainsConstants_expectConstantsInContext(
+      Fragment fragment, JsonObject parameters) throws Exception {
+
+    final FragmentContext fragmentContext = FragmentContext.from(fragment);
+    assertThat(fragmentContext.fragment().context().getJsonObject("_const").toString(), 
+    		sameJSONAs(parameters.toString()));
+  }
 
 }

--- a/knotx-knot/knotx-knot-service/src/test/java/io/knotx/knot/service/impl/FragmentContextTest.java
+++ b/knotx-knot/knotx-knot-service/src/test/java/io/knotx/knot/service/impl/FragmentContextTest.java
@@ -82,6 +82,7 @@ public class FragmentContextTest {
   @TestWith({
       "snippet_one_const.txt;{\"const1\":\"const1 value\"}",
       "snippet_two_consts.txt;{\"const1\":\"const1 value\",\"const2\":\"const2 value\"}",
+      "snippet_two_consts_no_prefix.txt;{\"const1\":\"const1 value\",\"const2\":\"const2 value\"}",
   })
   public void from_whenFragmentContainsConstants_expectConstantsInContext(
       Fragment fragment, JsonObject parameters) throws Exception {

--- a/knotx-knot/knotx-knot-service/src/test/resources/snippet_one_const.txt
+++ b/knotx-knot/knotx-knot-service/src/test/resources/snippet_one_const.txt
@@ -1,0 +1,5 @@
+<script
+  data-const-const1="const1 value"
+  type="text/knotx-snippet">
+  <h2>{{_const.const1}}</h2>
+</script>

--- a/knotx-knot/knotx-knot-service/src/test/resources/snippet_two_consts.txt
+++ b/knotx-knot/knotx-knot-service/src/test/resources/snippet_two_consts.txt
@@ -1,0 +1,6 @@
+<script
+  data-const-const1="const1 value"
+  data-const-const2="const2 value"
+  type="text/knotx-snippet">
+  <h2>{{_const.const1}}</h2>
+</script>

--- a/knotx-knot/knotx-knot-service/src/test/resources/snippet_two_consts_no_prefix.txt
+++ b/knotx-knot/knotx-knot-service/src/test/resources/snippet_two_consts_no_prefix.txt
@@ -1,0 +1,6 @@
+<script
+  const-const1="const1 value"
+  const-const2="const2 value"
+  type="text/knotx-snippet">
+  <h2>{{_const.const1}}</h2>
+</script>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Static fragment data passed to the handlebars. 

## Description
<!--- Describe your changes in detail -->
During FragmentContext initialization static data (prefixed with `data-const-` is now passed stored into the context. Prefix used for these properties is `_const`. Therefore data attribute `data-const-foo` can be referenced from handlebars as `{{_const.foo}]`

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Better code organization - and solution for some CMS systems that are not able to process the tags inside the fragment.
<!--- If it fixes an open issue, please link to the issue here. -->
Implementation of https://github.com/Cognifide/knotx/issues/391

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code style](https://github.com/Cognifide/knotx/blob/master/CONTRIBUTING.md#coding-conventions) of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

---
I hereby agree to the terms of the Knot.x Contributor License Agreement.
