### PR TITLE
Response code logging tweaks - different log levels for success, redi…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ All notable changes to Knot.x will be documented in this file.
 
 ## Unreleased
 List of changes that are finished but not yet released in any final version.
+ - [PR-427[(https://github.com/Cognifide/knotx/pull/427) - HttpRepositoryConnectorProxyImpl logging improvements
  - [PR-422](https://github.com/Cognifide/knotx/pull/422) - Configurable Handlebars delimiters
 
 ## 1.3.0

--- a/documentation/src/main/wiki/UpgradeNotes.md
+++ b/documentation/src/main/wiki/UpgradeNotes.md
@@ -6,6 +6,14 @@ versions. You may see all changes in the [Changelog](https://github.com/Cognifid
 
 ## Master
 
+ - [PR-427] https://github.com/Cognifide/knotx/pull/427 - HttpRepositoryConnectorProxyImpl logging improvements. Following log levels are now assigned depending on repository response status code:
+   ```2xx - success - log at debug
+   3xx - redirect - log at info
+   4xx - client error - log at warn
+   5xx - server error - log at error
+   other - log at warn
+   ```
+
 ## Version 1.3.0
 List of changes that are finished but not yet released in any final version.
  - [PR-376](https://github.com/Cognifide/knotx/pull/376) and [PR-397](https://github.com/Cognifide/knotx/pull/397) - Configuration changes:

--- a/knotx-core/src/main/java/io/knotx/repository/http/HttpRepositoryConnectorProxyImpl.java
+++ b/knotx-core/src/main/java/io/knotx/repository/http/HttpRepositoryConnectorProxyImpl.java
@@ -156,7 +156,7 @@ public class HttpRepositoryConnectorProxyImpl implements RepositoryConnectorProx
     } else if (HttpStatusClass.CLIENT_ERROR.contains(statusCode)) { // errors
       LOGGER.warn("Repository client error 4xx response: {}, Headers[{}]",
           statusCode, DataObjectsUtil.toString(httpResponse.headers()));
-    } else if (HttpStatusClass.SERVER_ERROR.contains(httpResponse.statusCode)) {
+    } else if (HttpStatusClass.SERVER_ERROR.contains(statusCode)) {
       LOGGER.error("Repository server error 5xx response: {}, Headers[{}]",
           statusCode, DataObjectsUtil.toString(httpResponse.headers()));
     } else {

--- a/knotx-core/src/main/java/io/knotx/repository/http/HttpRepositoryConnectorProxyImpl.java
+++ b/knotx-core/src/main/java/io/knotx/repository/http/HttpRepositoryConnectorProxyImpl.java
@@ -145,25 +145,27 @@ public class HttpRepositoryConnectorProxyImpl implements RepositoryConnectorProx
   }
 
   private ClientResponse toResponse(Buffer buffer, final HttpClientResponse httpResponse) {
-    if (HttpStatusClass.SUCCESS.contains(httpResponse.statusCode())) {
-      LOGGER.debug("Repository 2xx response: {}, Headers[{}]", httpResponse.statusCode(),
+    final int statusCode = httpResponse.statusCode();
+    
+    if (HttpStatusClass.SUCCESS.contains(statusCode)) {
+      LOGGER.debug("Repository 2xx response: {}, Headers[{}]", statusCode,
           DataObjectsUtil.toString(httpResponse.headers()));
-    } else if (HttpStatusClass.REDIRECTION.contains(httpResponse.statusCode())) { // redirect                                                                                  
-      LOGGER.info("Repository 3xx response: {}, Headers[{}]", httpResponse.statusCode(),
+    } else if (HttpStatusClass.REDIRECTION.contains(statusCode)) { // redirect                                                                                  
+      LOGGER.info("Repository 3xx response: {}, Headers[{}]", statusCode,
           DataObjectsUtil.toString(httpResponse.headers()));
-    } else if (HttpStatusClass.CLIENT_ERROR.contains(httpResponse.statusCode())) { // errors
+    } else if (HttpStatusClass.CLIENT_ERROR.contains(statusCode)) { // errors
       LOGGER.warn("Repository client error 4xx response: {}, Headers[{}]",
-          httpResponse.statusCode(), DataObjectsUtil.toString(httpResponse.headers()));
-    } else if (HttpStatusClass.SERVER_ERROR.contains(httpResponse.statusCode())) {
+          statusCode, DataObjectsUtil.toString(httpResponse.headers()));
+    } else if (HttpStatusClass.SERVER_ERROR.contains(httpResponse.statusCode)) {
       LOGGER.error("Repository server error 5xx response: {}, Headers[{}]",
-          httpResponse.statusCode(), DataObjectsUtil.toString(httpResponse.headers()));
+          statusCode, DataObjectsUtil.toString(httpResponse.headers()));
     } else {
       LOGGER.warn("Other response: {}, Headers[{}]",
-          httpResponse.statusCode(), DataObjectsUtil.toString(httpResponse.headers()));
+          statusCode, DataObjectsUtil.toString(httpResponse.headers()));
     }
 
     return new ClientResponse()
-        .setStatusCode(httpResponse.statusCode())
+        .setStatusCode(statusCode)
         .setHeaders(httpResponse.headers())
         .setBody(buffer.getDelegate());
 


### PR DESCRIPTION
…rect and error responses

<!--- Provide a general summary of your changes in the Title above -->
Currently every response from repository that return HTTP status code different than 200 is logged using ERROR logger level. The strategy has been adjusted.

## Description
<!--- Describe your changes in detail -->
2xx - success - log at debug
3xx - redirect - log at info
4xx - client error - log at warn
5xx - server error - log at error
other - log at warn 

https://github.com/Cognifide/knotx/issues/423

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Too many error messages may trigger unwanted warnings for devops. Error log level should indicate that something is wrong. 

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code style](https://github.com/Cognifide/knotx/blob/master/CONTRIBUTING.md#coding-conventions) of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

---
I hereby agree to the terms of the Knot.x Contributor License Agreement.
