### PR TITLE
Port unit and integration tests to JUnit 5

### DIFF
--- a/documentation/src/main/cheatsheet/cheatsheets.adoc
+++ b/documentation/src/main/cheatsheet/cheatsheets.adoc
@@ -4,7 +4,6 @@
 == ServiceAdapterOptions
 
 ++++
- Options describing how an ServiceAdapter will make connections with external HTTP services.
 ++++
 '''
 
@@ -104,6 +103,9 @@ Configure when to collect access log. True if after request arrives, false after
 [[AdapterRequest]]
 == AdapterRequest
 
+++++
+++++
+'''
 
 [cols=">25%,^25%,50%"]
 [frame="topbot"]
@@ -125,6 +127,9 @@ Set the client request
 [[AdapterResponse]]
 == AdapterResponse
 
+++++
+++++
+'''
 
 [cols=">25%,^25%,50%"]
 [frame="topbot"]

--- a/knotx-adapter/knotx-adapter-common/pom.xml
+++ b/knotx-adapter/knotx-adapter-common/pom.xml
@@ -57,20 +57,8 @@
       <artifactId>junit</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.powermock</groupId>
-      <artifactId>powermock-api-mockito</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.hamcrest</groupId>
       <artifactId>hamcrest-all</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.powermock</groupId>
-      <artifactId>powermock-module-junit4</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.mockito</groupId>
-      <artifactId>mockito-all</artifactId>
     </dependency>
     <dependency>
       <groupId>io.vertx</groupId>

--- a/knotx-adapter/knotx-adapter-service-http/pom.xml
+++ b/knotx-adapter/knotx-adapter-service-http/pom.xml
@@ -72,20 +72,12 @@
       <artifactId>junit</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.powermock</groupId>
-      <artifactId>powermock-api-mockito</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.hamcrest</groupId>
       <artifactId>hamcrest-all</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.powermock</groupId>
-      <artifactId>powermock-module-junit4</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.mockito</groupId>
-      <artifactId>mockito-all</artifactId>
+      <artifactId>mockito-core</artifactId>
     </dependency>
     <dependency>
       <groupId>io.vertx</groupId>

--- a/knotx-adapter/knotx-adapter-service-http/src/test/java/io/knotx/adapter/service/http/HttpClientFacadeTest.java
+++ b/knotx-adapter/knotx-adapter-service-http/src/test/java/io/knotx/adapter/service/http/HttpClientFacadeTest.java
@@ -47,7 +47,6 @@ import org.junit.rules.RuleChain;
 import org.junit.runner.RunWith;
 import org.mockito.Matchers;
 import org.mockito.Mockito;
-import org.powermock.api.mockito.PowerMockito;
 
 @RunWith(VertxUnitRunner.class)
 public class HttpClientFacadeTest {
@@ -80,7 +79,7 @@ public class HttpClientFacadeTest {
       TestContext context) throws Exception {
     Async async = context.async();
     // given
-    final WebClient mockedWebClient = PowerMockito.spy(webClient());
+    final WebClient mockedWebClient = Mockito.spy(webClient());
     HttpClientFacade clientFacade = new HttpClientFacade(mockedWebClient,
         getConfiguration());
     final JsonObject expectedResponse = new JsonObject(FileReader.readText("first-response.json"));
@@ -109,7 +108,7 @@ public class HttpClientFacadeTest {
       TestContext context) throws Exception {
     Async async = context.async();
     // given
-    final WebClient mockedWebClient = PowerMockito.spy(webClient());
+    final WebClient mockedWebClient = Mockito.spy(webClient());
     HttpClientFacade clientFacade = new HttpClientFacade(mockedWebClient,
         getConfiguration());
     final JsonObject expectedResponse = new JsonObject(FileReader.readText("first-response.json"));
@@ -141,7 +140,7 @@ public class HttpClientFacadeTest {
       TestContext context) throws Exception {
     Async async = context.async();
     // given
-    final WebClient mockedWebClient = PowerMockito.spy(webClient());
+    final WebClient mockedWebClient = Mockito.spy(webClient());
     HttpClientFacade clientFacade = new HttpClientFacade(mockedWebClient,
         getConfiguration());
 
@@ -168,7 +167,7 @@ public class HttpClientFacadeTest {
       TestContext context) throws Exception {
     Async async = context.async();
     // given
-    final WebClient mockedWebClient = PowerMockito.spy(webClient());
+    final WebClient mockedWebClient = Mockito.spy(webClient());
     HttpClientFacade clientFacade = new HttpClientFacade(mockedWebClient,
         getConfiguration());
 
@@ -197,7 +196,7 @@ public class HttpClientFacadeTest {
       TestContext context) throws Exception {
     Async async = context.async();
     // given
-    final WebClient mockedWebClient = PowerMockito.spy(webClient());
+    final WebClient mockedWebClient = Mockito.spy(webClient());
     HttpClientFacade clientFacade = new HttpClientFacade(mockedWebClient,
         getConfiguration());
 

--- a/knotx-core/pom.xml
+++ b/knotx-core/pom.xml
@@ -118,7 +118,6 @@
     <dependency>
       <groupId>io.knotx</groupId>
       <artifactId>knotx-junit5</artifactId>
-      <version>0.0.1-SNAPSHOT</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/knotx-core/pom.xml
+++ b/knotx-core/pom.xml
@@ -29,7 +29,9 @@
   <artifactId>knotx-core</artifactId>
 
   <name>Knot.x Core</name>
-  <description>Core Knot.x module consisting of Server, Repositories, Splitter, Assembler and Gateway.</description>
+  <description>Core Knot.x module consisting of Server, Repositories, Splitter, Assembler and
+    Gateway.
+  </description>
 
   <dependencies>
     <dependency>
@@ -114,13 +116,55 @@
 
     <!-- Tests -->
     <dependency>
-      <groupId>io.vertx</groupId>
-      <artifactId>vertx-unit</artifactId>
+      <groupId>io.knotx</groupId>
+      <artifactId>knotx-junit5</artifactId>
+      <version>0.0.1-SNAPSHOT</version>
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
+      <groupId>io.vertx</groupId>
+      <artifactId>vertx-junit5</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-params</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-migrationsupport</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.vintage</groupId>
+      <artifactId>junit-vintage-engine</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-junit-jupiter</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>io.vertx</groupId>
+      <artifactId>vertx-unit</artifactId>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>com.github.stefanbirkner</groupId>
@@ -137,10 +181,6 @@
     <dependency>
       <groupId>org.hamcrest</groupId>
       <artifactId>hamcrest-all</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.mockito</groupId>
-      <artifactId>mockito-all</artifactId>
     </dependency>
     <dependency>
       <groupId>commons-collections</groupId>

--- a/knotx-core/src/main/java/io/knotx/options/SnippetOptions.java
+++ b/knotx-core/src/main/java/io/knotx/options/SnippetOptions.java
@@ -17,6 +17,7 @@ package io.knotx.options;
 
 import io.vertx.codegen.annotations.DataObject;
 import io.vertx.core.json.JsonObject;
+import org.apache.commons.lang3.StringUtils;
 
 /**
  * Describes SnippetOptions Knot configuration
@@ -106,7 +107,7 @@ public class SnippetOptions {
    * @return a reference to this, so the API can be used fluently
    */
   public SnippetOptions setParamsPrefix(String paramsPrefix) {
-    this.paramsPrefix = paramsPrefix;
+    this.paramsPrefix = paramsPrefix == null ? StringUtils.EMPTY : paramsPrefix;
     return this;
   }
 }

--- a/knotx-core/src/test/java/io/knotx/assembler/FragmentAssemblerTest.java
+++ b/knotx-core/src/test/java/io/knotx/assembler/FragmentAssemblerTest.java
@@ -16,16 +16,13 @@
 package io.knotx.assembler;
 
 import io.knotx.dataobjects.KnotContext;
-import io.knotx.junit.rule.KnotxConfiguration;
-import io.knotx.junit.rule.TestVertxDeployer;
 import io.knotx.junit.util.FileReader;
 import io.knotx.junit.util.KnotContextFactory;
+import io.knotx.junit5.KnotxApplyConfiguration;
+import io.knotx.junit5.KnotxExtension;
 import io.knotx.reactivex.proxy.KnotProxy;
 import io.netty.handler.codec.http.HttpResponseStatus;
-import io.vertx.ext.unit.Async;
-import io.vertx.ext.unit.TestContext;
-import io.vertx.ext.unit.junit.RunTestOnContext;
-import io.vertx.ext.unit.junit.VertxUnitRunner;
+import io.vertx.junit5.VertxTestContext;
 import io.vertx.reactivex.core.Vertx;
 import java.io.IOException;
 import java.util.Arrays;
@@ -35,12 +32,11 @@ import java.util.function.Consumer;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.commons.lang3.tuple.Pair;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.RuleChain;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
-@RunWith(VertxUnitRunner.class)
+@ExtendWith(KnotxExtension.class)
 public class FragmentAssemblerTest {
 
   private final static String ADDRESS = "knotx.core.assembler";
@@ -48,102 +44,96 @@ public class FragmentAssemblerTest {
   private static final String SERVICES = "services";
   private static final String HANDLEBARS = "handlebars";
 
-  //Test Runner Rule of Verts
-  private RunTestOnContext vertx = new RunTestOnContext();
-
-  //Test Runner Rule of Knotx
-  private TestVertxDeployer knotx = new TestVertxDeployer(vertx);
-
-  //Junit Rule, sets up logger, prepares verts, starts verticles according to the config (supplied in annotation of test method)
-  @Rule
-  public RuleChain chain = RuleChain.outerRule(vertx).around(knotx);
-
   @Test
-  @KnotxConfiguration("io/knotx/assembler/test.unwrap.io.knotx.FragmentAssembler.json")
-  public void callAssemblerWithNoSnippets_expectInternalServerError(TestContext context)
-      throws Exception {
-    callAssemblerWithAssertions(context, null,
-        knotContext -> context.assertEquals(HttpResponseStatus.INTERNAL_SERVER_ERROR.code(),
+  @KnotxApplyConfiguration("io/knotx/assembler/test.unwrap.io.knotx.FragmentAssembler.json")
+  public void callAssemblerWithNoSnippets_expectInternalServerError(
+      VertxTestContext context, Vertx vertx) {
+    callAssemblerWithAssertions(context, vertx,
+        null,
+        knotContext -> Assertions.assertEquals(HttpResponseStatus.INTERNAL_SERVER_ERROR.code(),
             knotContext.getClientResponse().getStatusCode()
         ));
   }
 
   @Test
-  @KnotxConfiguration("io/knotx/assembler/test.unwrap.io.knotx.FragmentAssembler.json")
-  public void callAssemblerWithEmptySnippet_expectNoContentStatus(TestContext context)
-      throws Exception {
-    callAssemblerWithAssertions(context, Collections
+  @KnotxApplyConfiguration("io/knotx/assembler/test.unwrap.io.knotx.FragmentAssembler.json")
+  public void callAssemblerWithEmptySnippet_expectNoContentStatus(
+      VertxTestContext context, Vertx vertx) {
+    callAssemblerWithAssertions(context, vertx,
+        Collections
             .singletonList(new ImmutablePair<>(Collections.singletonList(RAW), StringUtils.SPACE)),
-        knotContext -> context.assertEquals(HttpResponseStatus.NO_CONTENT.code(),
+        knotContext -> Assertions.assertEquals(HttpResponseStatus.NO_CONTENT.code(),
             knotContext.getClientResponse().getStatusCode()));
   }
 
   @Test
-  @KnotxConfiguration("io/knotx/assembler/test.asIs.io.knotx.FragmentAssembler.json")
-  public void callAssemblerWithManySnippets_expectAsIsResult(TestContext context)
-      throws Exception {
+  @KnotxApplyConfiguration("io/knotx/assembler/test.asIs.io.knotx.FragmentAssembler.json")
+  public void callAssemblerWithManySnippets_expectAsIsResult(
+      VertxTestContext context, Vertx vertx) throws IOException {
     List<Pair<List<String>, String>> fragments = Arrays.asList(
         toPair("io/knotx/assembler/fragment1.txt", RAW),
         toPair("io/knotx/assembler/fragment2.txt", SERVICES, HANDLEBARS),
         toPair("io/knotx/assembler/fragment3.txt", RAW));
     String expectedResult = FileReader.readText("io/knotx/server/expectedAsIsResult.html");
-    callAssemblerWithAssertions(context, fragments,
+    callAssemblerWithAssertions(context, vertx,
+        fragments,
         knotContext -> {
-          context.assertEquals(HttpResponseStatus.OK.code(),
+          Assertions.assertEquals(HttpResponseStatus.OK.code(),
               knotContext.getClientResponse().getStatusCode());
-          context
+          Assertions
               .assertEquals(expectedResult, knotContext.getClientResponse().getBody().toString());
         });
   }
 
   @Test
-  @KnotxConfiguration("io/knotx/assembler/test.unwrap.io.knotx.FragmentAssembler.json")
-  public void callAssemblerWithManySnippets_expectUnwrapResult(TestContext context)
-      throws Exception {
+  @KnotxApplyConfiguration("io/knotx/assembler/test.unwrap.io.knotx.FragmentAssembler.json")
+  public void callAssemblerWithManySnippets_expectUnwrapResult(
+      VertxTestContext context, Vertx vertx) throws IOException {
     List<Pair<List<String>, String>> fragments = Arrays.asList(
         toPair("io/knotx/assembler/fragment1.txt", RAW),
         toPair("io/knotx/assembler/fragment2.txt", SERVICES, HANDLEBARS),
         toPair("io/knotx/assembler/fragment3.txt", RAW));
     String expectedResult = FileReader.readText("io/knotx/server/expectedUnwrapResult.html");
-    callAssemblerWithAssertions(context, fragments,
+    callAssemblerWithAssertions(context, vertx,
+        fragments,
         knotContext -> {
-          context.assertEquals(HttpResponseStatus.OK.code(),
+          Assertions.assertEquals(HttpResponseStatus.OK.code(),
               knotContext.getClientResponse().getStatusCode());
-          context
+          Assertions
               .assertEquals(expectedResult, knotContext.getClientResponse().getBody().toString());
         });
   }
 
   @Test
-  @KnotxConfiguration("io/knotx/assembler/test.ignore.io.knotx.FragmentAssembler.json")
-  public void callAssemblerWithManySnippets_expectIgnoreResult(TestContext context)
-      throws Exception {
+  @KnotxApplyConfiguration("io/knotx/assembler/test.ignore.io.knotx.FragmentAssembler.json")
+  public void callAssemblerWithManySnippets_expectIgnoreResult(
+      VertxTestContext context, Vertx vertx) throws IOException {
     List<Pair<List<String>, String>> fragments = Arrays.asList(
         toPair("io/knotx/assembler/fragment1.txt", RAW),
         toPair("io/knotx/assembler/fragment2.txt", SERVICES, HANDLEBARS),
         toPair("io/knotx/assembler/fragment3.txt", RAW));
     String expectedResult = FileReader.readText("io/knotx/server/expectedIgnoreResult.html");
-    callAssemblerWithAssertions(context, fragments,
+    callAssemblerWithAssertions(context, vertx,
+        fragments,
         knotContext -> {
-          context.assertEquals(HttpResponseStatus.OK.code(),
+          Assertions.assertEquals(HttpResponseStatus.OK.code(),
               knotContext.getClientResponse().getStatusCode());
-          context
+          Assertions
               .assertEquals(expectedResult, knotContext.getClientResponse().getBody().toString());
         });
   }
 
-  private void callAssemblerWithAssertions(TestContext context,
+  private void callAssemblerWithAssertions(
+      VertxTestContext context, Vertx vertx,
       List<Pair<List<String>, String>> fragments,
-      Consumer<KnotContext> testFunction) {
-    Async async = context.async();
-    KnotProxy service = KnotProxy.createProxy(new Vertx(vertx.vertx()), ADDRESS);
+      Consumer<KnotContext> verifyResultFunction) {
+    KnotProxy service = KnotProxy.createProxy(vertx, ADDRESS);
 
     service.rxProcess(KnotContextFactory.create(fragments))
-        .map(ctx -> Pair.of(async, ctx))
-        .doOnSuccess(success -> testFunction.accept(success.getRight()))
+        .doOnSuccess(verifyResultFunction::accept)
         .subscribe(
-            success -> async.complete(),
-            context::fail
+            success -> context.completeNow(),
+            context::failNow
         );
   }
 

--- a/knotx-core/src/test/java/io/knotx/assembler/UnprocessedFragmentStrategyTest.java
+++ b/knotx-core/src/test/java/io/knotx/assembler/UnprocessedFragmentStrategyTest.java
@@ -18,61 +18,64 @@ package io.knotx.assembler;
 import static org.hamcrest.Matchers.equalToIgnoringWhiteSpace;
 import static org.junit.Assert.assertThat;
 
-import com.googlecode.zohhak.api.Configure;
-import com.googlecode.zohhak.api.TestWith;
-import com.googlecode.zohhak.api.runners.ZohhakRunner;
 import io.knotx.dataobjects.Fragment;
 import io.knotx.fragments.SnippetPatterns;
-import io.knotx.junit.coercers.KnotxCoercers;
-import io.knotx.junit.util.FileReader;
+import io.knotx.junit5.KnotxTestUtils;
+import io.knotx.junit5.KnotxArgumentConverter;
 import io.knotx.options.SnippetOptions;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.converter.ConvertWith;
+import org.junit.jupiter.params.provider.CsvSource;
 
-@RunWith(ZohhakRunner.class)
-@Configure(separator = ";", coercers = KnotxCoercers.class)
 public class UnprocessedFragmentStrategyTest {
 
-  @TestWith({
+  @ParameterizedTest
+  @CsvSource(delimiter = ';', value = {
       "io/knotx/assembler/simple_snippet.txt;io/knotx/assembler/simple_snippet.txt;script;data-knotx-",
       "io/knotx/assembler/customTag_snippet.txt;io/knotx/assembler/customTag_snippet.txt;knotx:snippet;data-knotx-",
       "io/knotx/assembler/raw_fragment.txt;io/knotx/assembler/raw_fragment.txt;script;data-knotx-",
       "io/knotx/assembler/customTagAndParamsPrefix_snippet.txt;io/knotx/assembler/customTagAndParamsPrefix_snippet.txt;knotx:snippet;"
   })
-  public void asIs_whenConfiguredSnippetTag_expectIgnoredContent(Fragment fragment,
+  public void asIs_whenConfiguredSnippetTag_expectIgnoredContent(
+      @ConvertWith(KnotxArgumentConverter.class) Fragment fragment,
       String expectedContentFileName, String snippetTagName, String paramsPrefix) throws Exception {
     final String unwrappedContent = UnprocessedFragmentStrategy.AS_IS
         .get(fragment, new SnippetPatterns(buildOptions(snippetTagName, paramsPrefix)));
-    final String expectedContent = FileReader.readText(expectedContentFileName);
+    final String expectedContent = KnotxTestUtils.readText(expectedContentFileName);
 
     assertThat(unwrappedContent, equalToIgnoringWhiteSpace(expectedContent));
   }
 
-  @TestWith({
+  @ParameterizedTest
+  @CsvSource(delimiter = ';', value = {
       "io/knotx/assembler/simple_snippet.txt;io/knotx/assembler/simple_snippet-expected_unwrapped_content.txt;script;data-knotx-",
       "io/knotx/assembler/customTag_snippet.txt|knotx:snippet;io/knotx/assembler/simple_snippet-expected_unwrapped_content.txt;knotx:snippet;data-knotx-",
       "io/knotx/assembler/big_snippet.txt;io/knotx/assembler/big_snippet-expected_unwrapped_content.txt;script;data-knotx-",
       "io/knotx/assembler/customTagAndParamsPrefix_snippet.txt|knotx:snippet|;io/knotx/assembler/simple_snippet-expected_unwrapped_content.txt;knotx:snippet;"
   })
-  public void unwrap_whenConfiguredSnippetTag_expectDefinedContentWithComments(Fragment fragment,
+  public void unwrap_whenConfiguredSnippetTag_expectDefinedContentWithComments(
+      @ConvertWith(KnotxArgumentConverter.class) Fragment fragment,
       String expectedContentFileName, String snippetTagName, String paramsPrefix) throws Exception {
     final String unwrappedContent = UnprocessedFragmentStrategy.UNWRAP
         .get(fragment, new SnippetPatterns(buildOptions(snippetTagName, paramsPrefix)));
-    final String expectedContent = FileReader.readText(expectedContentFileName);
+    final String expectedContent = KnotxTestUtils.readText(expectedContentFileName);
 
     assertThat(unwrappedContent, equalToIgnoringWhiteSpace(expectedContent));
   }
 
-  @TestWith({
+  @ParameterizedTest
+  @CsvSource(delimiter = ';', value = {
       "io/knotx/assembler/simple_snippet.txt;io/knotx/assembler/simple_snippet-expected_ignored_content.txt;script;data-knotx-",
       "io/knotx/assembler/customTag_snippet.txt;io/knotx/assembler/simple_snippet-expected_ignored_content.txt;knotx:snippet;data-knotx-",
       "io/knotx/assembler/raw_fragment.txt;io/knotx/assembler/raw_fragment.txt;script;data-knotx-"
       //when fragment is a raw fragment, it is not ignored
   })
-  public void ignore_whenConfiguredSnippetTag_expectIgnoredContent(Fragment fragment,
+  public void ignore_whenConfiguredSnippetTag_expectIgnoredContent(
+      @ConvertWith(KnotxArgumentConverter.class) Fragment fragment,
       String expectedContentFileName, String snippetTagName, String paramsPrefix) throws Exception {
     final String unwrappedContent = UnprocessedFragmentStrategy.IGNORE
         .get(fragment, new SnippetPatterns(buildOptions(snippetTagName, paramsPrefix)));
-    final String expectedContent = FileReader.readText(expectedContentFileName);
+    final String expectedContent = KnotxTestUtils.readText(expectedContentFileName);
 
     assertThat(unwrappedContent, equalToIgnoringWhiteSpace(expectedContent));
   }

--- a/knotx-core/src/test/java/io/knotx/http/AllowedHeadersFilterTest.java
+++ b/knotx-core/src/test/java/io/knotx/http/AllowedHeadersFilterTest.java
@@ -21,7 +21,7 @@ import com.google.common.collect.Lists;
 import java.util.List;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 
 public class AllowedHeadersFilterTest {

--- a/knotx-core/src/test/java/io/knotx/http/StringToPatternFunctionTest.java
+++ b/knotx-core/src/test/java/io/knotx/http/StringToPatternFunctionTest.java
@@ -15,19 +15,19 @@
  */
 package io.knotx.http;
 
-import org.junit.BeforeClass;
-import org.junit.Test;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-
-import static org.junit.Assert.*;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 public class StringToPatternFunctionTest {
 
   private static StringToPatternFunction stringToPattern;
 
-  @BeforeClass
+  @BeforeAll
   public static void setUp() {
     stringToPattern = StringToPatternFunction.getInstance();
   }

--- a/knotx-core/src/test/java/io/knotx/server/KnotxRepositoryHandlerTest.java
+++ b/knotx-core/src/test/java/io/knotx/server/KnotxRepositoryHandlerTest.java
@@ -23,7 +23,6 @@ import static org.mockito.Mockito.when;
 
 import io.knotx.dataobjects.ClientResponse;
 import io.knotx.dataobjects.KnotContext;
-import io.knotx.server.KnotxRepositoryHandler;
 import io.knotx.server.configuration.KnotxServerOptions;
 import io.knotx.server.configuration.RepositoryEntry;
 import io.vertx.reactivex.core.MultiMap;
@@ -31,13 +30,16 @@ import io.vertx.reactivex.core.Vertx;
 import io.vertx.reactivex.core.buffer.Buffer;
 import io.vertx.reactivex.core.http.HttpServerResponse;
 import io.vertx.reactivex.ext.web.RoutingContext;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.WARN)
 public class KnotxRepositoryHandlerTest {
 
   @Mock
@@ -57,7 +59,7 @@ public class KnotxRepositoryHandlerTest {
 
   private KnotxRepositoryHandler tested;
 
-  @Before
+  @BeforeEach
   public void setUp() {
     tested = KnotxRepositoryHandler.create(vertx, configuration);
     when(httpServerResponse.setStatusCode(anyInt())).thenReturn(httpServerResponse);

--- a/knotx-core/src/test/java/io/knotx/server/KnotxServerOptionsRepositoriesTest.java
+++ b/knotx-core/src/test/java/io/knotx/server/KnotxServerOptionsRepositoriesTest.java
@@ -22,14 +22,14 @@ import io.knotx.junit.util.FileReader;
 import io.knotx.server.configuration.KnotxFlowSettings;
 import io.knotx.server.configuration.KnotxServerOptions;
 import io.vertx.core.json.JsonObject;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class KnotxServerOptionsRepositoriesTest {
 
   private KnotxFlowSettings flowConfiguration;
 
-  @Before
+  @BeforeEach
   public void before() throws Exception {
     JsonObject config = new JsonObject(FileReader.readText(
         "io/knotx/server/test-config-server.json"));
@@ -37,8 +37,7 @@ public class KnotxServerOptionsRepositoriesTest {
   }
 
   @Test
-  public void whenConfigWithRepositoryMappings_expectRepositoryAddressOnMatchingPaths()
-      throws Exception {
+  public void whenConfigWithRepositoryMappings_expectRepositoryAddressOnMatchingPaths() {
     assertThat(flowConfiguration.repositoryForPath("/content/local/simple.html").get().getAddress(),
         equalTo("knotx.repository.filesystem"));
     assertThat(flowConfiguration.repositoryForPath("/content/simple.html").get().getAddress(),
@@ -46,8 +45,7 @@ public class KnotxServerOptionsRepositoriesTest {
   }
 
   @Test
-  public void whenConfigWithRepositoryMappings_expectNoRepositoryAddressOnNotMatchingPaths()
-      throws Exception {
+  public void whenConfigWithRepositoryMappings_expectNoRepositoryAddressOnNotMatchingPaths() {
     assertThat(flowConfiguration.repositoryForPath("/content2/local/simple.html").isPresent(),
         equalTo(false));
     assertThat(flowConfiguration.repositoryForPath("/service/simple.html").isPresent(), equalTo(false));

--- a/knotx-core/src/test/java/io/knotx/server/KnotxServerOptionsRoutingTest.java
+++ b/knotx-core/src/test/java/io/knotx/server/KnotxServerOptionsRoutingTest.java
@@ -25,8 +25,8 @@ import io.knotx.server.configuration.MethodRoutingEntries;
 import io.vertx.core.http.HttpMethod;
 import io.vertx.core.json.JsonObject;
 import java.util.Map;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class KnotxServerOptionsRoutingTest {
 
@@ -34,7 +34,7 @@ public class KnotxServerOptionsRoutingTest {
   private static final int SECOND_IDX = 1;
   private Map<String, MethodRoutingEntries> engineRouting;
 
-  @Before
+  @BeforeEach
   public void before() throws Exception {
     engineRouting = new KnotxServerOptions(
         new JsonObject(FileReader.readText("io/knotx/server/test-config-server.json"))).getDefaultFlow()
@@ -42,14 +42,14 @@ public class KnotxServerOptionsRoutingTest {
   }
 
   @Test
-  public void whenConfigWithTwoRoutingMethods_expectTwoMethodsInRouting() throws Exception {
+  public void whenConfigWithTwoRoutingMethods_expectTwoMethodsInRouting() {
     assertThat(engineRouting.keySet().size(), equalTo(2));
     assertThat(engineRouting.keySet(), hasItem(HttpMethod.GET.toString()));
     assertThat(engineRouting.keySet(), hasItem(HttpMethod.POST.toString()));
   }
 
   @Test
-  public void whenConfigWithGetRouting_expectTwoRoutings() throws Exception {
+  public void whenConfigWithGetRouting_expectTwoRoutings() {
     assertThat(engineRouting.get(HttpMethod.GET.toString()).getItems().size(), equalTo(2));
     assertThat(engineRouting.get(HttpMethod.GET.toString()).getItems().get(FIRST_IDX).getPath(),
         equalTo(".*/local/.*\\.html"));
@@ -60,7 +60,7 @@ public class KnotxServerOptionsRoutingTest {
   }
 
   @Test
-  public void whenConfigWithPostRouting_expectTwoRoutings() throws Exception {
+  public void whenConfigWithPostRouting_expectTwoRoutings() {
     assertThat(engineRouting.get(HttpMethod.POST.toString()).getItems().size(), equalTo(2));
     assertThat(engineRouting.get(HttpMethod.POST.toString()).getItems().get(FIRST_IDX).getPath(),
         equalTo(".*/local/.*\\.html"));
@@ -73,8 +73,7 @@ public class KnotxServerOptionsRoutingTest {
   }
 
   @Test
-  public void whenConfigWithGetRoutingAndTransitions_expectTransitionsExistsWhenDefined()
-      throws Exception {
+  public void whenConfigWithGetRoutingAndTransitions_expectTransitionsExistsWhenDefined() {
     assertThat(engineRouting.get(HttpMethod.GET.toString()).getItems().get(FIRST_IDX).getOnTransition().isEmpty(),
         equalTo(false));
     assertThat(engineRouting.get(HttpMethod.GET.toString()).getItems().get(FIRST_IDX).getOnTransition().keySet().size(),
@@ -94,8 +93,7 @@ public class KnotxServerOptionsRoutingTest {
   }
 
   @Test
-  public void whenConfigWithPostRoutingAndTransitions_expectTransitionsExistsWhenDefined()
-      throws Exception {
+  public void whenConfigWithPostRoutingAndTransitions_expectTransitionsExistsWhenDefined() {
     assertThat(engineRouting.get(HttpMethod.POST.toString()).getItems().get(FIRST_IDX).getOnTransition().isEmpty(),
         equalTo(false));
     assertThat(engineRouting.get(HttpMethod.POST.toString()).getItems().get(FIRST_IDX).getOnTransition().keySet().size(),

--- a/knotx-core/src/test/java/io/knotx/server/KnotxServerRoutingTest.java
+++ b/knotx-core/src/test/java/io/knotx/server/KnotxServerRoutingTest.java
@@ -16,207 +16,183 @@
 package io.knotx.server;
 
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
 import io.knotx.dataobjects.ClientResponse;
 import io.knotx.dataobjects.KnotContext;
-import io.knotx.junit.rule.KnotxConfiguration;
-import io.knotx.junit.rule.TestVertxDeployer;
+import io.knotx.junit5.KnotxApplyConfiguration;
+import io.knotx.junit5.KnotxExtension;
+import io.knotx.junit5.KnotxTestUtils;
 import io.netty.handler.codec.http.HttpResponseStatus;
 import io.reactivex.Observable;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.http.HttpMethod;
-import io.vertx.ext.unit.Async;
-import io.vertx.ext.unit.TestContext;
-import io.vertx.ext.unit.junit.RunTestOnContext;
-import io.vertx.ext.unit.junit.VertxUnitRunner;
+import io.vertx.junit5.VertxTestContext;
 import io.vertx.reactivex.core.MultiMap;
 import io.vertx.reactivex.core.Vertx;
 import io.vertx.reactivex.core.http.HttpClient;
-import io.vertx.reactivex.core.http.HttpClientRequest;
 import io.vertx.reactivex.core.http.HttpClientResponse;
 import java.util.function.Consumer;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.RuleChain;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
-@RunWith(VertxUnitRunner.class)
+@ExtendWith(KnotxExtension.class)
 public class KnotxServerRoutingTest {
 
-  private static final int KNOTX_SERVER_PORT = 9092;
-  private static final String KNOTX_SERVER_ADDRESS = "localhost";
   public static final String EXPECTED_XSERVER_HEADER_VALUE = "Knot.x";
   public static final String EXPECTED_RESPONSE_HEADER = "X-Server";
+  private static final int KNOTX_SERVER_PORT = 9092;
+  private static final String KNOTX_SERVER_ADDRESS = "localhost";
 
-  private RunTestOnContext vertx = new RunTestOnContext();
-
-  private TestVertxDeployer knotx = new TestVertxDeployer(vertx);
-
-  @Rule
-  public RuleChain chain = RuleChain.outerRule(vertx).around(knotx);
-
-  private static Observable<HttpClientResponse> request(HttpClient client, HttpMethod method,
-      int port, String domain, String uri,
-      Consumer<HttpClientRequest> requestBuilder) {
-    return Observable.unsafeCreate(subscriber -> {
-      HttpClientRequest req = client.request(method, port, domain, uri);
-      Observable<HttpClientResponse> resp = req.toObservable();
-      resp.subscribe(subscriber);
-      requestBuilder.accept(req);
-      req.end();
-    });
-  }
 
   @Test
-  @KnotxConfiguration("io/knotx/server/test-server.json")
-  public void whenRequestingWithInvalidQuery_expectBadRequest(TestContext context) {
-    HttpClient client = Vertx.newInstance(vertx.vertx()).createHttpClient();
-    Async async = context.async();
+  @KnotxApplyConfiguration("io/knotx/server/test-server.json")
+  public void whenRequestingWithInvalidQuery_expectBadRequest(
+      VertxTestContext context, Vertx vertx) {
+    HttpClient client = vertx.createHttpClient();
     client.getNow(KNOTX_SERVER_PORT, KNOTX_SERVER_ADDRESS,
         "/content/local/simple.html?q=~!@\\||$%^&*()_=-%22;;%27%22:%3C%3E/?]}{",
         resp -> {
-          context.assertEquals(HttpResponseStatus.BAD_REQUEST.code(), resp.statusCode());
+          assertEquals(HttpResponseStatus.BAD_REQUEST.code(), resp.statusCode());
           client.close();
-          async.complete();
+          context.completeNow();
         });
   }
 
   @Test
-  @KnotxConfiguration("io/knotx/server/test-server.json")
-  public void whenRequestingGetLocalPath_expectLocalAC(TestContext context) {
-    createPassThroughKnot("test-splitter");
-    createPassThroughKnot("test-assembler");
-    createSimpleKnot("A-engine", "+A", "go-c");
-    createSimpleKnot("C-engine", "+C", null);
-    testGetRequest(context, "/content/local/simple.html", "local+A+C");
+  @KnotxApplyConfiguration("io/knotx/server/test-server.json")
+  public void whenRequestingGetLocalPath_expectLocalAC(
+      VertxTestContext context, Vertx vertx) {
+    createPassThroughKnot(vertx, "test-splitter");
+    createPassThroughKnot(vertx, "test-assembler");
+    createSimpleKnot(vertx, "A-engine", "+A", "go-c");
+    createSimpleKnot(vertx, "C-engine", "+C", null);
+    testGetRequest(context, vertx, "/content/local/simple.html", "local+A+C");
   }
 
   @Test
-  @KnotxConfiguration("io/knotx/server/test-server.json")
-  public void whenRequestingGetGlobalPath_expectGlobalC(TestContext context) {
-    createPassThroughKnot("test-splitter");
-    createPassThroughKnot("test-assembler");
-    createSimpleKnot("C-engine", "+C", null);
-    testGetRequest(context, "/content/simple.html", "global+C");
+  @KnotxApplyConfiguration("io/knotx/server/test-server.json")
+  public void whenRequestingGetGlobalPath_expectGlobalC(
+      VertxTestContext context, Vertx vertx) {
+    createPassThroughKnot(vertx, "test-splitter");
+    createPassThroughKnot(vertx, "test-assembler");
+    createSimpleKnot(vertx, "C-engine", "+C", null);
+    testGetRequest(context, vertx, "/content/simple.html", "global+C");
   }
 
   @Test
-  @KnotxConfiguration("io/knotx/server/test-server.json")
+  @KnotxApplyConfiguration("io/knotx/server/test-server.json")
   public void whenRequestingPostLocalPathWithFirstTransition_expectLocalApostBC(
-      TestContext context) {
-    Async async = context.async();
-
-    createPassThroughKnot("test-splitter");
-    createPassThroughKnot("test-assembler");
-    createSimpleKnot("A-post-engine", "+Apost", "go-b");
-    createSimpleKnot("B-engine", "+B", "go-c");
-    createSimpleKnot("C-engine", "+C", null);
-    testPostRequest("/content/local/simple.html",
+      VertxTestContext context, Vertx vertx) {
+    createPassThroughKnot(vertx, "test-splitter");
+    createPassThroughKnot(vertx, "test-assembler");
+    createSimpleKnot(vertx, "A-post-engine", "+Apost", "go-b");
+    createSimpleKnot(vertx, "B-engine", "+B", "go-c");
+    createSimpleKnot(vertx, "C-engine", "+C", null);
+    testPostRequest(vertx, "/content/local/simple.html",
         resp -> {
-          context.assertEquals(HttpResponseStatus.OK.code(), resp.statusCode());
-          context.assertTrue(resp.getHeader(EXPECTED_RESPONSE_HEADER) != null);
-          context.assertEquals(EXPECTED_XSERVER_HEADER_VALUE,
+          assertEquals(HttpResponseStatus.OK.code(), resp.statusCode());
+          assertNotNull(resp.getHeader(EXPECTED_RESPONSE_HEADER));
+          assertEquals(EXPECTED_XSERVER_HEADER_VALUE,
               resp.getHeader(EXPECTED_RESPONSE_HEADER));
           resp.bodyHandler(body -> {
             try {
-              context.assertEquals("local+Apost+B+C", body.toString(),
+              assertEquals("local+Apost+B+C", body.toString(),
                   "Wrong engines processed request, expected " + "local+Apost+B+C");
             } catch (Exception e) {
-              context.fail(e);
+              context.failNow(e);
             }
-            async.complete();
+            context.completeNow();
           });
         });
   }
 
   @Test
-  @KnotxConfiguration("io/knotx/server/test-server.json")
+  @KnotxApplyConfiguration("io/knotx/server/test-server.json")
   public void whenRequestingPostLocalPathWithAlternateTransition_expectLocalApostC(
-      TestContext context) {
-    Async async = context.async();
-
-    createPassThroughKnot("test-splitter");
-    createPassThroughKnot("test-assembler");
-    createSimpleKnot("A-post-engine", "+Apost", "go-c");
-    createSimpleKnot("C-engine", "+C", null);
-    testPostRequest("/content/local/simple.html",
+      VertxTestContext context, Vertx vertx) {
+    createPassThroughKnot(vertx, "test-splitter");
+    createPassThroughKnot(vertx, "test-assembler");
+    createSimpleKnot(vertx, "A-post-engine", "+Apost", "go-c");
+    createSimpleKnot(vertx, "C-engine", "+C", null);
+    testPostRequest(vertx, "/content/local/simple.html",
         resp -> {
-          context.assertEquals(HttpResponseStatus.OK.code(), resp.statusCode());
-          context.assertTrue(resp.getHeader(EXPECTED_RESPONSE_HEADER) != null);
-          context.assertEquals(EXPECTED_XSERVER_HEADER_VALUE,
+          assertEquals(HttpResponseStatus.OK.code(), resp.statusCode());
+          assertNotNull(resp.getHeader(EXPECTED_RESPONSE_HEADER));
+          assertEquals(EXPECTED_XSERVER_HEADER_VALUE,
               resp.getHeader(EXPECTED_RESPONSE_HEADER));
           resp.bodyHandler(body -> {
             try {
-              context.assertEquals("local+Apost+C", body.toString(),
+              assertEquals("local+Apost+C", body.toString(),
                   "Wrong engines processed request, expected " + "local+Apost+C");
             } catch (Exception e) {
-              context.fail(e);
+              context.failNow(e);
             }
-            async.complete();
+            context.completeNow();
           });
         });
   }
 
   @Test
-  @KnotxConfiguration("io/knotx/server/test-server.json")
-  public void whenRequestingPostGlobalPath_expectGlobalBC(TestContext context) {
-    Async async = context.async();
+  @KnotxApplyConfiguration("io/knotx/server/test-server.json")
+  public void whenRequestingPostGlobalPath_expectGlobalBC(
+      VertxTestContext context, Vertx vertx) {
+    createPassThroughKnot(vertx, "test-splitter");
+    createPassThroughKnot(vertx, "test-assembler");
+    createSimpleKnot(vertx, "B-engine", "+B", "go-c");
+    createSimpleKnot(vertx, "C-engine", "+C", null);
 
-    createPassThroughKnot("test-splitter");
-    createPassThroughKnot("test-assembler");
-    createSimpleKnot("B-engine", "+B", "go-c");
-    createSimpleKnot("C-engine", "+C", null);
-
-    testPostRequest("/content/simple.html", resp -> {
-      context.assertEquals(HttpResponseStatus.OK.code(), resp.statusCode());
-      context.assertTrue(resp.getHeader(EXPECTED_RESPONSE_HEADER) != null);
-      context.assertEquals(EXPECTED_XSERVER_HEADER_VALUE,
+    testPostRequest(vertx, "/content/simple.html", resp -> {
+      assertEquals(HttpResponseStatus.OK.code(), resp.statusCode());
+      assertNotNull(resp.getHeader(EXPECTED_RESPONSE_HEADER));
+      assertEquals(EXPECTED_XSERVER_HEADER_VALUE,
           resp.getHeader(EXPECTED_RESPONSE_HEADER));
       resp.bodyHandler(body -> {
         try {
-          context.assertEquals("global+B+C", body.toString(),
+          assertEquals("global+B+C", body.toString(),
               "Wrong engines processed request, expected " + "global+B+C");
         } catch (Exception e) {
-          context.fail(e);
+          context.failNow(e);
         }
-        async.complete();
+        context.completeNow();
       });
     });
   }
 
   @Test
-  @KnotxConfiguration("io/knotx/server/test-server.json")
+  @KnotxApplyConfiguration("io/knotx/server/test-server.json")
   public void whenRequestingPostGlobalPathAndActionDoRedirect_expectRedirectResponse(
-      TestContext context) {
-    Async async = context.async();
-
-    createPassThroughKnot("test-splitter");
-    createPassThroughKnot("test-assembler");
-    createSimpleFailingKnot("A-post-engine", HttpResponseStatus.MOVED_PERMANENTLY.code(),
+      VertxTestContext context, Vertx vertx) {
+    createPassThroughKnot(vertx, "test-splitter");
+    createPassThroughKnot(vertx, "test-assembler");
+    createSimpleFailingKnot(vertx, "A-post-engine", HttpResponseStatus.MOVED_PERMANENTLY.code(),
         MultiMap.caseInsensitiveMultiMap().add("location", "/content/failed.html"));
 
-    testPostRequest("/content/local/simple.html", resp -> {
-      context.assertEquals(HttpResponseStatus.MOVED_PERMANENTLY.code(), resp.statusCode());
-      context.assertEquals("/content/failed.html", resp.getHeader("location"));
-      context.assertTrue(resp.getHeader(EXPECTED_RESPONSE_HEADER) != null);
-      context.assertEquals(EXPECTED_XSERVER_HEADER_VALUE,
+    testPostRequest(vertx, "/content/local/simple.html", resp -> {
+      assertEquals(HttpResponseStatus.MOVED_PERMANENTLY.code(), resp.statusCode());
+      assertEquals("/content/failed.html", resp.getHeader("location"));
+      assertNotNull(resp.getHeader(EXPECTED_RESPONSE_HEADER));
+      assertEquals(EXPECTED_XSERVER_HEADER_VALUE,
           resp.getHeader(EXPECTED_RESPONSE_HEADER));
-      async.complete();
+      context.completeNow();
     });
   }
 
   @Test
-  @KnotxConfiguration("io/knotx/server/test-server.json")
-  public void whenRequestingGetWithCustomFlowProcessing(TestContext context) {
-    createPassThroughKnot("responseprovider");
-    createSimpleGatewayKnot("gateway", "next");
-    createSimpleKnot("requestprocessor", "message", null);
-    testGetRequest(context, "/customFlow/remote/simple.json", "message");
+  @KnotxApplyConfiguration("io/knotx/server/test-server.json")
+  public void whenRequestingGetWithCustomFlowProcessing(
+      VertxTestContext context, Vertx vertx) {
+    createPassThroughKnot(vertx, "responseprovider");
+    createSimpleGatewayKnot(vertx, "gateway", "next");
+    createSimpleKnot(vertx, "requestprocessor", "message", null);
+    testGetRequest(context, vertx, "/customFlow/remote/simple.json", "message");
   }
 
-  private void testPostRequest(String url, Consumer<HttpClientResponse> expectedResponse) {
-    HttpClient client = Vertx.newInstance(vertx.vertx()).createHttpClient();
+  private void testPostRequest(Vertx vertx, String url, Consumer<HttpClientResponse> expectedResponse) {
+    HttpClient client = vertx.createHttpClient();
     String testBody = "a=b";
-    Observable<HttpClientResponse> request = request(client, HttpMethod.POST, KNOTX_SERVER_PORT,
+    Observable<HttpClientResponse> request = KnotxTestUtils.asyncRequest(client, HttpMethod.POST, KNOTX_SERVER_PORT,
         KNOTX_SERVER_ADDRESS, url, req -> {
           req.headers().set("content-length", String.valueOf(testBody.length()));
           req.headers().set("content-type", "application/x-www-form-urlencoded");
@@ -226,41 +202,41 @@ public class KnotxServerRoutingTest {
     request.subscribe(expectedResponse::accept);
   }
 
-  private void testGetRequest(TestContext context, String url, String expectedResult) {
-    HttpClient client = Vertx.newInstance(vertx.vertx()).createHttpClient();
-    Async async = context.async();
+  private void testGetRequest(VertxTestContext context, Vertx vertx, String url, String expectedResult) {
+    HttpClient client = vertx.createHttpClient();
+
     client.getNow(KNOTX_SERVER_PORT, KNOTX_SERVER_ADDRESS, url,
         resp -> resp.bodyHandler(body -> {
-          context.assertEquals(HttpResponseStatus.OK.code(), resp.statusCode());
-          context.assertTrue(resp.getHeader(EXPECTED_RESPONSE_HEADER) != null);
-          context.assertEquals(EXPECTED_XSERVER_HEADER_VALUE,
+          assertEquals(HttpResponseStatus.OK.code(), resp.statusCode());
+          assertNotNull(resp.getHeader(EXPECTED_RESPONSE_HEADER));
+          assertEquals(EXPECTED_XSERVER_HEADER_VALUE,
               resp.getHeader(EXPECTED_RESPONSE_HEADER));
           try {
-            context.assertEquals(expectedResult, body.toString(),
+            assertEquals(expectedResult, body.toString(),
                 "Wrong engines processed request, expected " + expectedResult);
           } catch (Exception e) {
-            context.fail(e);
+            context.failNow(e);
           }
           client.close();
-          async.complete();
+          context.completeNow();
         }));
   }
 
-  private void createPassThroughKnot(String address) {
-    MockKnotProxy.register(vertx.vertx(), address);
+  private void createPassThroughKnot(Vertx vertx, String address) {
+    MockKnotProxy.register(vertx.getDelegate(), address);
   }
 
-  private void createSimpleKnot(final String address, final String addToBody,
+  private void createSimpleKnot(Vertx vertx, final String address, final String addToBody,
       final String transition) {
     Consumer<KnotContext> simpleKnot = knotContext -> {
       Buffer inBody = knotContext.getClientResponse().getBody();
       knotContext.getClientResponse().setBody(inBody.appendString(addToBody));
       knotContext.setTransition(transition);
     };
-    MockKnotProxy.register(vertx.vertx(), address, simpleKnot);
+    MockKnotProxy.register(vertx.getDelegate(), address, simpleKnot);
   }
 
-  private void createSimpleGatewayKnot(final String address, final String transition) {
+  private void createSimpleGatewayKnot(Vertx vertx, final String address, final String transition) {
     Consumer<KnotContext> simpleKnot = knotContext -> {
       ClientResponse clientResponse = new ClientResponse();
       clientResponse.setBody(Buffer.buffer());
@@ -268,15 +244,15 @@ public class KnotxServerRoutingTest {
       knotContext.setClientResponse(clientResponse);
       knotContext.setTransition(transition);
     };
-    MockKnotProxy.register(vertx.vertx(), address, simpleKnot);
+    MockKnotProxy.register(vertx.getDelegate(), address, simpleKnot);
   }
 
-  private void createSimpleFailingKnot(final String address, final int statusCode,
+  private void createSimpleFailingKnot(Vertx vertx, final String address, final int statusCode,
       final MultiMap headers) {
     Consumer<KnotContext> simpleKnot = knotContext -> {
       knotContext.getClientResponse().setStatusCode(statusCode).setHeaders(headers);
       knotContext.setTransition(null);
     };
-    MockKnotProxy.register(vertx.vertx(), address, simpleKnot);
+    MockKnotProxy.register(vertx.getDelegate(), address, simpleKnot);
   }
 }

--- a/knotx-core/src/test/java/io/knotx/server/SupportedMethodsAndPathsHandlerTest.java
+++ b/knotx-core/src/test/java/io/knotx/server/SupportedMethodsAndPathsHandlerTest.java
@@ -23,8 +23,8 @@ import io.vertx.core.http.HttpMethod;
 import io.vertx.core.json.JsonObject;
 import io.vertx.reactivex.core.http.HttpServerRequest;
 import io.vertx.reactivex.ext.web.RoutingContext;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 public class SupportedMethodsAndPathsHandlerTest {
@@ -33,7 +33,7 @@ public class SupportedMethodsAndPathsHandlerTest {
   private KnotxFlowSettings customFlow;
   private SupportedMethodsAndPathsHandler tested;
 
-  @Before
+  @BeforeEach
   public void before() throws Exception {
     defaultFlow = new KnotxFlowSettings(
         new JsonObject(FileReader.readText("io/knotx/server/GETOnlyDefaultFlow.json")));
@@ -47,8 +47,7 @@ public class SupportedMethodsAndPathsHandlerTest {
   }
 
   @Test
-  public void handle_whenRequestPathAndMethodAllowedInDefaultFlow_expectRequestAccepted()
-      throws Exception {
+  public void handle_whenRequestPathAndMethodAllowedInDefaultFlow_expectRequestAccepted() {
     RoutingContext context = mockContext("/content/page.html", HttpMethod.GET);
     tested.handle(context);
 
@@ -56,8 +55,7 @@ public class SupportedMethodsAndPathsHandlerTest {
   }
 
   @Test
-  public void handle_whenRequestPathNotAllowedInDefaultFlowAndAllowedInCustomFlow_expectRequestAccepted()
-      throws Exception {
+  public void handle_whenRequestPathNotAllowedInDefaultFlowAndAllowedInCustomFlow_expectRequestAccepted() {
     RoutingContext context = mockContext("/services/feature.json", HttpMethod.GET);
     tested.handle(context);
 
@@ -65,8 +63,7 @@ public class SupportedMethodsAndPathsHandlerTest {
   }
 
   @Test
-  public void handle_whenRequestPathAllowedButMethodNotAllowedInDefaultFlow_expectRequestFailedMethodNotAllowed()
-      throws Exception {
+  public void handle_whenRequestPathAllowedButMethodNotAllowedInDefaultFlow_expectRequestFailedMethodNotAllowed() {
     RoutingContext context = mockContext("/content/page.html", HttpMethod.POST);
     tested.handle(context);
 
@@ -74,8 +71,7 @@ public class SupportedMethodsAndPathsHandlerTest {
   }
 
   @Test
-  public void handle_whenRequestPathAllowedButMethodNotAllowedInCustomFlow_expectRequestFailedMethodNotAllowed()
-      throws Exception {
+  public void handle_whenRequestPathAllowedButMethodNotAllowedInCustomFlow_expectRequestFailedMethodNotAllowed() {
     RoutingContext context = mockContext("/content/page.html", HttpMethod.POST);
     tested.handle(context);
 
@@ -83,7 +79,7 @@ public class SupportedMethodsAndPathsHandlerTest {
   }
 
   @Test
-  public void handle_whenRequestPathNotAllowed_expectRequestFailedNotFound() throws Exception {
+  public void handle_whenRequestPathNotAllowed_expectRequestFailedNotFound() {
     RoutingContext context = mockContext("/notallowed/page.html", HttpMethod.GET);
     tested.handle(context);
 

--- a/knotx-core/src/test/java/io/knotx/splitter/HtmlFragmentSplitterContentTest.java
+++ b/knotx-core/src/test/java/io/knotx/splitter/HtmlFragmentSplitterContentTest.java
@@ -18,25 +18,21 @@ package io.knotx.splitter;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
 
-import com.googlecode.zohhak.api.Configure;
-import com.googlecode.zohhak.api.TestWith;
-import com.googlecode.zohhak.api.runners.ZohhakRunner;
 import io.knotx.dataobjects.Fragment;
 import io.knotx.junit.util.FileReader;
 import io.knotx.options.SnippetOptions;
 import java.util.List;
-import org.junit.Before;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 
-@RunWith(ZohhakRunner.class)
-@Configure(separator = ";")
 public class HtmlFragmentSplitterContentTest {
 
   private List<Fragment> defaultSnippetTagFragments;
   private List<Fragment> customSnippetTagFragments;
   private List<Fragment> customSnippetCustomParamsPrefixFragments;
 
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
     defaultSnippetTagFragments = new HtmlFragmentSplitter(
         new SnippetOptions()
@@ -56,7 +52,8 @@ public class HtmlFragmentSplitterContentTest {
             .readText("io/knotx/splitter/test-many-fragments-custom-snippet-and-prefix.html"));
   }
 
-  @TestWith({
+  @ParameterizedTest
+  @CsvSource(delimiter = ';', value = {
       "0;io/knotx/splitter/fragments/1.txt",
       "1;io/knotx/splitter/fragments/2-snippet.txt",
       "2;io/knotx/splitter/fragments/3.txt",
@@ -73,7 +70,8 @@ public class HtmlFragmentSplitterContentTest {
         equalTo(FileReader.readText(fragmentFile).trim()));
   }
 
-  @TestWith({
+  @ParameterizedTest
+  @CsvSource(delimiter = ';', value = {
       "0;io/knotx/splitter/fragments/1.txt",
       "1;io/knotx/splitter/fragments/2-custom-snippet.txt",
       "2;io/knotx/splitter/fragments/3.txt",
@@ -90,7 +88,8 @@ public class HtmlFragmentSplitterContentTest {
         equalTo(FileReader.readText(fragmentFile).trim()));
   }
 
-  @TestWith({
+  @ParameterizedTest
+  @CsvSource(delimiter = ';', value = {
       "0;io/knotx/splitter/fragments/1.txt",
       "1;io/knotx/splitter/fragments/2-custom-snippet-no-prefix.txt",
       "2;io/knotx/splitter/fragments/3.txt",

--- a/knotx-core/src/test/java/io/knotx/splitter/HtmlFragmentSplitterTest.java
+++ b/knotx-core/src/test/java/io/knotx/splitter/HtmlFragmentSplitterTest.java
@@ -24,14 +24,9 @@ import io.knotx.junit.util.FileReader;
 import io.knotx.options.SnippetOptions;
 import java.util.List;
 import java.util.stream.IntStream;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.Test;
 
 public class HtmlFragmentSplitterTest {
-
-  @Rule
-  public final ExpectedException expectedException = ExpectedException.none();
 
   private static final String DEFAULT_SCRIPT_TAG = "script";
   private static final String CUSTOM_SCRIPT_TAG = "knotx:snippet";

--- a/knotx-core/src/test/java/io/knotx/splitter/HtmlFragmentSplitterVerticleTest.java
+++ b/knotx-core/src/test/java/io/knotx/splitter/HtmlFragmentSplitterVerticleTest.java
@@ -15,75 +15,63 @@
  */
 package io.knotx.splitter;
 
+import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
 import io.knotx.dataobjects.KnotContext;
-import io.knotx.junit.rule.KnotxConfiguration;
-import io.knotx.junit.rule.TestVertxDeployer;
 import io.knotx.junit.util.FileReader;
 import io.knotx.junit.util.KnotContextFactory;
+import io.knotx.junit5.KnotxApplyConfiguration;
+import io.knotx.junit5.KnotxExtension;
 import io.knotx.reactivex.proxy.KnotProxy;
 import io.netty.handler.codec.http.HttpResponseStatus;
-import io.vertx.ext.unit.Async;
-import io.vertx.ext.unit.TestContext;
-import io.vertx.ext.unit.junit.RunTestOnContext;
-import io.vertx.ext.unit.junit.VertxUnitRunner;
+import io.vertx.junit5.VertxTestContext;
 import io.vertx.reactivex.core.Vertx;
 import java.util.function.Consumer;
-import org.apache.commons.lang3.tuple.Pair;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.RuleChain;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
-@RunWith(VertxUnitRunner.class)
+@ExtendWith(KnotxExtension.class)
 public class HtmlFragmentSplitterVerticleTest {
 
   private final static String ADDRESS = "knotx.core.splitter";
 
-  //Test Runner Rule of Verts
-  private RunTestOnContext vertx = new RunTestOnContext();
-
-  //Test Runner Rule of Knotx
-  private TestVertxDeployer knotx = new TestVertxDeployer(vertx);
-
-  //Junit Rule, sets up logger, prepares verts, starts verticles according to the config (supplied in annotation of test method)
-  @Rule
-  public RuleChain chain = RuleChain.outerRule(vertx).around(knotx);
-
   @Test
-  @KnotxConfiguration("io/knotx/splitter/knotx-fragment-splitter-test.json")
-  public void callSplitterWithEmptyBody_expectNotFoundResponse(TestContext context)
-      throws Exception {
-    callFragmentSplitterWithAssertions(context, "",
+  @KnotxApplyConfiguration("io/knotx/splitter/knotx-fragment-splitter-test.json")
+  public void callSplitterWithEmptyBody_expectNotFoundResponse(
+      VertxTestContext context, Vertx vertx) {
+    callFragmentSplitterWithAssertions(context, vertx, "",
         knotContext -> {
-          context.assertEquals(knotContext.getClientResponse().getStatusCode(),
+          assertEquals(knotContext.getClientResponse().getStatusCode(),
               HttpResponseStatus.NOT_FOUND.code());
-          context.assertFalse(knotContext.getFragments() != null);
+          assertNull(knotContext.getFragments());
         });
   }
 
   @Test
-  @KnotxConfiguration("io/knotx/splitter/knotx-fragment-splitter-test.json")
-  public void callSplitterWithManySnippets_expectNineFragments(TestContext context)
-      throws Exception {
-    callFragmentSplitterWithAssertions(context, FileReader.readText(
+  @KnotxApplyConfiguration("io/knotx/splitter/knotx-fragment-splitter-test.json")
+  public void callSplitterWithManySnippets_expectNineFragments(
+      VertxTestContext context, Vertx vertx) throws Exception {
+    callFragmentSplitterWithAssertions(context, vertx, FileReader.readText(
         "io/knotx/splitter/test-many-fragments.html"),
         knotContext -> {
-          context.assertTrue(knotContext.getFragments() != null);
-          context.assertEquals(knotContext.getFragments().size(), 9);
+          assertNotNull(knotContext.getFragments());
+          assertEquals(knotContext.getFragments().size(), 9);
         });
   }
 
-  private void callFragmentSplitterWithAssertions(TestContext context, String template,
+  private void callFragmentSplitterWithAssertions(
+      VertxTestContext context, Vertx vertx,
+      String template,
       Consumer<KnotContext> testFunction) {
-    Async async = context.async();
-    KnotProxy service = KnotProxy.createProxy(new Vertx(vertx.vertx()), ADDRESS);
+    KnotProxy service = KnotProxy.createProxy(vertx, ADDRESS);
 
     service.rxProcess(KnotContextFactory.empty(template))
-        .map(ctx -> Pair.of(async, ctx))
-        .doOnSuccess(success -> testFunction.accept(success.getRight()))
+        .doOnSuccess(testFunction::accept)
         .subscribe(
-            success -> async.complete(),
-            context::fail
+            success -> context.completeNow(),
+            context::failNow
         );
   }
 

--- a/knotx-it-tests/pom.xml
+++ b/knotx-it-tests/pom.xml
@@ -86,7 +86,6 @@
     <dependency>
       <groupId>io.knotx</groupId>
       <artifactId>knotx-junit5</artifactId>
-      <version>0.0.1-SNAPSHOT</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/knotx-it-tests/pom.xml
+++ b/knotx-it-tests/pom.xml
@@ -84,29 +84,35 @@
 
     <!-- Tests -->
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.powermock</groupId>
-      <artifactId>powermock-api-mockito</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.hamcrest</groupId>
-      <artifactId>hamcrest-all</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.powermock</groupId>
-      <artifactId>powermock-module-junit4</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.mockito</groupId>
-      <artifactId>mockito-all</artifactId>
+      <groupId>io.knotx</groupId>
+      <artifactId>knotx-junit5</artifactId>
+      <version>0.0.1-SNAPSHOT</version>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>io.vertx</groupId>
-      <artifactId>vertx-unit</artifactId>
+      <artifactId>vertx-junit5</artifactId>
       <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-params</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-migrationsupport</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.hamcrest</groupId>
+      <artifactId>hamcrest-all</artifactId>
     </dependency>
     <dependency>
       <groupId>io.vertx</groupId>

--- a/knotx-knot/knotx-knot-action/pom.xml
+++ b/knotx-knot/knotx-knot-action/pom.xml
@@ -59,31 +59,6 @@
 
     <!-- Tests -->
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.powermock</groupId>
-      <artifactId>powermock-api-mockito</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.hamcrest</groupId>
-      <artifactId>hamcrest-all</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.powermock</groupId>
-      <artifactId>powermock-module-junit4</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.mockito</groupId>
-      <artifactId>mockito-all</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>io.vertx</groupId>
-      <artifactId>vertx-unit</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>io.vertx</groupId>
       <artifactId>vertx-config</artifactId>
       <scope>test</scope>

--- a/knotx-knot/knotx-knot-action/src/test/java/io/knotx/knot/action/ActionKnotProxyVerticleTest.java
+++ b/knotx-knot/knotx-knot-action/src/test/java/io/knotx/knot/action/ActionKnotProxyVerticleTest.java
@@ -15,6 +15,10 @@
  */
 package io.knotx.knot.action;
 
+import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
 import com.google.common.collect.Lists;
 import io.knotx.dataobjects.AdapterRequest;
 import io.knotx.dataobjects.AdapterResponse;
@@ -22,10 +26,10 @@ import io.knotx.dataobjects.ClientResponse;
 import io.knotx.dataobjects.Fragment;
 import io.knotx.dataobjects.KnotContext;
 import io.knotx.http.MultiMapCollector;
-import io.knotx.junit.rule.KnotxConfiguration;
-import io.knotx.junit.rule.TestVertxDeployer;
-import io.knotx.junit.util.FileReader;
 import io.knotx.junit.util.KnotContextFactory;
+import io.knotx.junit5.KnotxApplyConfiguration;
+import io.knotx.junit5.KnotxExtension;
+import io.knotx.junit5.KnotxTestUtils;
 import io.knotx.proxy.AdapterProxy;
 import io.knotx.reactivex.proxy.KnotProxy;
 import io.netty.handler.codec.http.HttpResponseStatus;
@@ -35,10 +39,7 @@ import io.vertx.core.Future;
 import io.vertx.core.Handler;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.http.HttpMethod;
-import io.vertx.ext.unit.Async;
-import io.vertx.ext.unit.TestContext;
-import io.vertx.ext.unit.junit.RunTestOnContext;
-import io.vertx.ext.unit.junit.VertxUnitRunner;
+import io.vertx.junit5.VertxTestContext;
 import io.vertx.reactivex.core.MultiMap;
 import io.vertx.reactivex.core.Vertx;
 import io.vertx.serviceproxy.ServiceBinder;
@@ -52,12 +53,10 @@ import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
 import org.jsoup.nodes.Entities;
 import org.jsoup.parser.Parser;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.RuleChain;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
-@RunWith(VertxUnitRunner.class)
+@ExtendWith(KnotxExtension.class)
 public class ActionKnotProxyVerticleTest {
 
   public static final String KNOT_TRANSITION = "next";
@@ -71,114 +70,101 @@ public class ActionKnotProxyVerticleTest {
       .escapeMode(Entities.EscapeMode.xhtml)
       .indentAmount(0)
       .prettyPrint(false);
-  //Test Runner Rule of Verts
-  private RunTestOnContext vertx = new RunTestOnContext();
 
-  //Test Runner Rule of Knotx
-  private TestVertxDeployer knotx = new TestVertxDeployer(vertx);
-
-  //Junit Rule, sets up logger, prepares verts, starts verticles according to the config (supplied in annotation of test method)
-  @Rule
-  public RuleChain chain = RuleChain.outerRule(vertx).around(knotx);
 
   @Test
-  @KnotxConfiguration("knotx-test.json")
-  public void callGetWithNoActionFragments_expectResponseOkNoFragmentChanges(TestContext context)
-      throws Exception {
-    String expectedTemplatingFragment = FileReader.readText("fragment_templating_out.txt");
+  @KnotxApplyConfiguration("knotx-test.json")
+  public void callGetWithNoActionFragments_expectResponseOkNoFragmentChanges(
+      VertxTestContext context, Vertx vertx) throws Exception {
+    String expectedTemplatingFragment = KnotxTestUtils.readText("fragment_templating_out.txt");
     KnotContext knotContext = createKnotContext(FIRST_FRAGMENT, LAST_FRAGMENT,
         "fragment_templating_in.txt");
     knotContext.getClientRequest().setMethod(HttpMethod.GET);
 
-    callActionKnotWithAssertions(context, knotContext,
+    callActionKnotWithAssertions(context, vertx, knotContext,
         clientResponse -> {
-          context.assertEquals(HttpResponseStatus.OK.code(),
+          assertEquals(HttpResponseStatus.OK.code(),
               clientResponse.getClientResponse().getStatusCode());
-          context.assertTrue(clientResponse.getTransition() != null);
-          context.assertEquals(KNOT_TRANSITION, clientResponse.getTransition());
-          context.assertTrue(clientResponse.getFragments() != null);
+          assertNotNull(clientResponse.getTransition());
+          assertEquals(KNOT_TRANSITION, clientResponse.getTransition());
+          assertNotNull(clientResponse.getFragments());
 
           List<Fragment> fragments = clientResponse.getFragments();
-          context.assertEquals(FIRST_FRAGMENT.content(), fragments.get(0).content());
-          context.assertEquals(expectedTemplatingFragment, fragments.get(1).content());
-          context.assertEquals(LAST_FRAGMENT.content(), fragments.get(2).content());
-        },
-        error -> context.fail(error.getMessage()));
+          assertEquals(FIRST_FRAGMENT.content(), fragments.get(0).content());
+          assertEquals(expectedTemplatingFragment, fragments.get(1).content());
+          assertEquals(LAST_FRAGMENT.content(), fragments.get(2).content());
+        });
   }
 
   @Test
-  @KnotxConfiguration("knotx-test.json")
-  public void callGetWithTwoActionFragments_expectResponseOkTwoFragmentChanges(TestContext context)
-      throws Exception {
-    String expectedRedirectFormFragment = FileReader.readText("fragment_form_redirect_out.txt");
-    String expectedSelfFormFragment = FileReader.readText("fragment_form_self_out.txt");
+  @KnotxApplyConfiguration("knotx-test.json")
+  public void callGetWithTwoActionFragments_expectResponseOkTwoFragmentChanges(
+      VertxTestContext context, Vertx vertx) throws Exception {
+    String expectedRedirectFormFragment = KnotxTestUtils.readText("fragment_form_redirect_out.txt");
+    String expectedSelfFormFragment = KnotxTestUtils.readText("fragment_form_self_out.txt");
     KnotContext knotContext = createKnotContext(FIRST_FRAGMENT, LAST_FRAGMENT,
         "fragment_form_redirect_in.txt", "fragment_form_self_in.txt");
     knotContext.getClientRequest().setMethod(HttpMethod.GET);
 
-    callActionKnotWithAssertions(context, knotContext,
+    callActionKnotWithAssertions(context, vertx, knotContext,
         clientResponse -> {
-          context.assertEquals(HttpResponseStatus.OK.code(),
+          assertEquals(HttpResponseStatus.OK.code(),
               clientResponse.getClientResponse().getStatusCode());
-          context.assertTrue(clientResponse.getTransition() != null);
-          context.assertEquals(KNOT_TRANSITION, clientResponse.getTransition());
-          context.assertTrue(clientResponse.getFragments() != null);
+          assertNotNull(clientResponse.getTransition());
+          assertEquals(KNOT_TRANSITION, clientResponse.getTransition());
+          assertNotNull(clientResponse.getFragments());
 
           List<Fragment> fragments = clientResponse.getFragments();
-          context.assertEquals(FIRST_FRAGMENT.content(), fragments.get(0).content());
-          context
-              .assertEquals(clean(expectedRedirectFormFragment), clean(fragments.get(1).content()));
-          context.assertEquals(clean(expectedSelfFormFragment), clean(fragments.get(2).content()));
-          context.assertEquals(LAST_FRAGMENT.content(), fragments.get(3).content());
-        },
-        error -> context.fail(error.getMessage()));
+          assertEquals(FIRST_FRAGMENT.content(), fragments.get(0).content());
+          assertEquals(clean(expectedRedirectFormFragment), clean(fragments.get(1).content()));
+          assertEquals(clean(expectedSelfFormFragment), clean(fragments.get(2).content()));
+          assertEquals(LAST_FRAGMENT.content(), fragments.get(3).content());
+        });
   }
 
   @Test
-  @KnotxConfiguration("knotx-test.json")
+  @KnotxApplyConfiguration("knotx-test.json")
   public void callGetWithActionFragmentWithoutIdentifier_expectResponseOkWithOneFragmentChanges(
-      TestContext context) throws Exception {
+      VertxTestContext context, Vertx vertx) throws Exception {
     KnotContext knotContext = createKnotContext("fragment_form_no_identifier_in.txt");
-    String expectedFragmentHtml = FileReader.readText("fragment_form_no_identifier_out.txt");
+    String expectedFragmentHtml = KnotxTestUtils.readText("fragment_form_no_identifier_out.txt");
     knotContext.getClientRequest().setMethod(HttpMethod.GET);
 
-    callActionKnotWithAssertions(context, knotContext,
+    callActionKnotWithAssertions(context, vertx, knotContext,
         clientResponse -> {
-          context.assertEquals(HttpResponseStatus.OK.code(),
+          assertEquals(HttpResponseStatus.OK.code(),
               clientResponse.getClientResponse().getStatusCode());
-          context.assertTrue(clientResponse.getTransition() != null);
-          context.assertEquals(KNOT_TRANSITION, clientResponse.getTransition());
-          context.assertTrue(clientResponse.getFragments() != null);
+          assertNotNull(clientResponse.getTransition());
+          assertEquals(KNOT_TRANSITION, clientResponse.getTransition());
+          assertNotNull(clientResponse.getFragments());
 
           List<Fragment> fragments = clientResponse.getFragments();
-          context.assertEquals(fragments.size(), 1);
-          context.assertEquals(clean(expectedFragmentHtml), clean(fragments.get(0).content()));
-        },
-        error -> context.fail(error.getMessage()));
+          assertEquals(fragments.size(), 1);
+          assertEquals(clean(expectedFragmentHtml), clean(fragments.get(0).content()));
+        });
   }
 
   @Test
-  @KnotxConfiguration("knotx-test.json")
+  @KnotxApplyConfiguration("knotx-test.json")
   public void callGetWithActionFragmentActionHandlerNotExists_expectStatusCode500(
-      TestContext context) throws Exception {
+      VertxTestContext context, Vertx vertx) throws Exception {
     KnotContext knotContext = createKnotContext("fragment_form_actionhandler_not_exists_in.txt");
     knotContext.getClientRequest().setMethod(HttpMethod.GET);
 
-    callActionKnotWithAssertions(context, knotContext,
+    callActionKnotWithAssertions(context, vertx, knotContext,
         clientResponse -> {
-          context.assertEquals(HttpResponseStatus.INTERNAL_SERVER_ERROR.code(),
+          assertEquals(HttpResponseStatus.INTERNAL_SERVER_ERROR.code(),
               clientResponse.getClientResponse().getStatusCode());
-          context.assertFalse(clientResponse.getTransition() != null);
-          context.assertFalse(clientResponse.getFragments() != null);
-        },
-        error -> context.fail(error.getMessage()));
+          assertNull(clientResponse.getTransition());
+          assertNull(clientResponse.getFragments());
+        });
   }
 
   @Test
-  @KnotxConfiguration("knotx-test.json")
+  @KnotxApplyConfiguration("knotx-test.json")
   public void callPostWithTwoActionFragments_expectResponseOkWithTransitionStep2(
-      TestContext context) throws Exception {
-    createMockAdapter("address-redirect", "", "step2");
+      VertxTestContext context, Vertx vertx) throws Exception {
+    createMockAdapter(vertx, "address-redirect", "", "step2");
     KnotContext knotContext = createKnotContext("fragment_form_redirect_in.txt",
         "fragment_form_self_in.txt");
     knotContext.getClientRequest()
@@ -186,66 +172,61 @@ public class ActionKnotProxyVerticleTest {
         .setFormAttributes(MultiMap.caseInsensitiveMultiMap()
             .add(HIDDEN_INPUT_TAG_NAME, FRAGMENT_REDIRECT_IDENTIFIER));
 
-    callActionKnotWithAssertions(context, knotContext,
+    callActionKnotWithAssertions(context, vertx, knotContext,
         clientResponse -> {
-          context.assertEquals(HttpResponseStatus.MOVED_PERMANENTLY.code(),
+          assertEquals(HttpResponseStatus.MOVED_PERMANENTLY.code(),
               clientResponse.getClientResponse().getStatusCode());
-          context.assertEquals("/content/form/step2.html",
+          assertEquals("/content/form/step2.html",
               clientResponse.getClientResponse().getHeaders().get("Location"));
-          context.assertFalse(clientResponse.getTransition() != null);
-          context.assertFalse(clientResponse.getFragments() != null);
-        },
-        error -> context.fail(error.getMessage()));
+          assertNull(clientResponse.getTransition());
+          assertNull(clientResponse.getFragments());
+        });
   }
 
   @Test
-  @KnotxConfiguration("knotx-test.json")
+  @KnotxApplyConfiguration("knotx-test.json")
   public void callPostWithActionFragmentWithoutRequestedFragmentIdentifier_expectStatusCode500(
-      TestContext context) throws Exception {
+      VertxTestContext context, Vertx vertx) throws Exception {
     KnotContext knotContext = createKnotContext("fragment_form_incorrect_identifier_in.txt");
     knotContext.getClientRequest().setMethod(HttpMethod.POST);
 
-    callActionKnotWithAssertions(context, knotContext,
+    callActionKnotWithAssertions(context, vertx, knotContext,
         clientResponse -> {
-          context.assertEquals(HttpResponseStatus.INTERNAL_SERVER_ERROR.code(),
+          assertEquals(HttpResponseStatus.INTERNAL_SERVER_ERROR.code(),
               clientResponse.getClientResponse().getStatusCode());
-          context.assertFalse(clientResponse.getFragments() != null);
-          context.assertFalse(clientResponse.getTransition() != null);
-        },
-        error -> context.fail(error.getMessage()));
+          assertNull(clientResponse.getFragments());
+          assertNull(clientResponse.getTransition());
+        });
   }
 
   @Test
-  @KnotxConfiguration("knotx-test.json")
+  @KnotxApplyConfiguration("knotx-test.json")
   public void callPostWithActionFragmentWithIncorrectSnippetId_expectStatusCode500(
-      TestContext context) throws Exception {
+      VertxTestContext context, Vertx vertx) throws Exception {
     KnotContext knotContext = createKnotContext("fragment_form_redirect_in.txt");
     knotContext.getClientRequest().setMethod(HttpMethod.POST)
         .setFormAttributes(
             MultiMap.caseInsensitiveMultiMap().add(HIDDEN_INPUT_TAG_NAME, "snippet_id_not_exists"));
 
-    callActionKnotWithAssertions(context, knotContext,
+    callActionKnotWithAssertions(context, vertx, knotContext,
         clientResponse -> {
-          context.assertEquals(HttpResponseStatus.INTERNAL_SERVER_ERROR.code(),
+          assertEquals(HttpResponseStatus.INTERNAL_SERVER_ERROR.code(),
               clientResponse.getClientResponse().getStatusCode());
-          context.assertFalse(clientResponse.getFragments() != null);
-          context.assertFalse(clientResponse.getTransition() != null);
-        },
-        error -> context.fail(error.getMessage()));
+          assertNull(clientResponse.getFragments());
+          assertNull(clientResponse.getTransition());
+        });
   }
 
-  private void callActionKnotWithAssertions(TestContext context, KnotContext knotContext,
-      Consumer<KnotContext> onSuccess,
-      Consumer<Throwable> onError) {
-    Async async = context.async();
-
-    KnotProxy actionKnot = KnotProxy.createProxy(new Vertx(vertx.vertx()), ADDRESS);
+  private void callActionKnotWithAssertions(
+      VertxTestContext context, Vertx vertx, KnotContext knotContext,
+      Consumer<KnotContext> onSuccess) {
+    KnotProxy actionKnot = KnotProxy.createProxy(vertx, ADDRESS);
 
     actionKnot.rxProcess(knotContext)
         .doOnSuccess(onSuccess)
         .subscribe(
-            success -> async.complete(),
-            onError
+            success -> context.completeNow(),
+            context::failNow
         );
   }
 
@@ -258,7 +239,7 @@ public class ActionKnotProxyVerticleTest {
     List<Fragment> fragments = Lists.newArrayList();
     Optional.ofNullable(firstFragment).ifPresent(fragments::add);
     for (String file : snippetFilenames) {
-      String fileContent = FileReader.readText(file);
+      String fileContent = KnotxTestUtils.readText(file);
       String fragmentIdentifiers = Jsoup.parse(fileContent).getElementsByAttribute(FRAGMENT_KNOTS)
           .attr(
               FRAGMENT_KNOTS);
@@ -278,11 +259,11 @@ public class ActionKnotProxyVerticleTest {
         .trim();
   }
 
-  private void createMockAdapter(String address, String addToBody, String signal) {
-    createMockAdapter(address, addToBody, signal, Collections.emptyMap());
+  private void createMockAdapter(Vertx vertx, String address, String addToBody, String signal) {
+    createMockAdapter(vertx, address, addToBody, signal, Collections.emptyMap());
   }
 
-  private void createMockAdapter(String address, String addToBody, String signal,
+  private void createMockAdapter(Vertx vertx, String address, String addToBody, String signal,
       Map<String, List<String>> headers) {
     Function<AdapterRequest, AdapterResponse> adapter = adapterRequest -> {
       ClientResponse response = new ClientResponse();
@@ -293,7 +274,7 @@ public class ActionKnotProxyVerticleTest {
       return new AdapterResponse().setResponse(response).setSignal(signal);
     };
 
-    new ServiceBinder(vertx.vertx())
+    new ServiceBinder(vertx.getDelegate())
         .setAddress(address)
         .register(AdapterProxy.class, new MockAdapterImpl(adapter));
   }

--- a/knotx-knot/knotx-knot-handlebars/pom.xml
+++ b/knotx-knot/knotx-knot-handlebars/pom.xml
@@ -71,33 +71,8 @@
 
     <!-- Tests -->
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.powermock</groupId>
-      <artifactId>powermock-api-mockito</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.hamcrest</groupId>
-      <artifactId>hamcrest-all</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.powermock</groupId>
-      <artifactId>powermock-module-junit4</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.mockito</groupId>
-      <artifactId>mockito-all</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>io.vertx</groupId>
-      <artifactId>vertx-unit</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>com.googlecode.zohhak</groupId>
-      <artifactId>zohhak</artifactId>
+      <artifactId>mockito-core</artifactId>
     </dependency>
     <dependency>
       <groupId>io.knotx</groupId>

--- a/knotx-knot/knotx-knot-handlebars/src/test/java/io/knotx/handlebars/JsonObjectValueResolverTest.java
+++ b/knotx-knot/knotx-knot-handlebars/src/test/java/io/knotx/handlebars/JsonObjectValueResolverTest.java
@@ -21,24 +21,22 @@ import static org.hamcrest.core.IsEqual.equalTo;
 import com.github.jknack.handlebars.Context;
 import com.github.jknack.handlebars.Handlebars;
 import com.github.jknack.handlebars.Template;
-import com.google.common.io.CharStreams;
-import com.google.common.io.Resources;
+import io.knotx.junit5.KnotxTestUtils;
 import io.knotx.knot.templating.handlebars.JsonObjectValueResolver;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
-import java.io.InputStreamReader;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class JsonObjectValueResolverTest {
 
   private String expected;
   private Template template;
 
-  @Before
+  @BeforeEach
   public void before() throws Exception {
-    template = new Handlebars().compileInline(readFile("sample.hbs"));
-    expected = readFile("expected").trim();
+    template = new Handlebars().compileInline(KnotxTestUtils.readText("sample.hbs"));
+    expected = KnotxTestUtils.readText("expected").trim();
   }
 
   @Test
@@ -61,11 +59,6 @@ public class JsonObjectValueResolverTest {
     assertThat(compiled, equalTo(expected));
   }
 
-  private String readFile(String path) throws Exception {
-    return CharStreams
-        .toString(new InputStreamReader(Resources.getResource(path).openStream(), "UTF-8"));
-  }
-
   private JsonObject programmaticModel() {
     return new JsonObject().put("sample",
         new JsonObject().put("result",
@@ -77,6 +70,6 @@ public class JsonObjectValueResolverTest {
   }
 
   private JsonObject filebasedModel() throws Exception {
-    return new JsonObject(readFile("testObject.json"));
+    return new JsonObject(KnotxTestUtils.readText("testObject.json"));
   }
 }

--- a/knotx-knot/knotx-knot-service/pom.xml
+++ b/knotx-knot/knotx-knot-service/pom.xml
@@ -54,33 +54,8 @@
 
     <!-- Tests -->
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.powermock</groupId>
-      <artifactId>powermock-api-mockito</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.hamcrest</groupId>
-      <artifactId>hamcrest-all</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.powermock</groupId>
-      <artifactId>powermock-module-junit4</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.mockito</groupId>
-      <artifactId>mockito-all</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>io.vertx</groupId>
-      <artifactId>vertx-unit</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>com.googlecode.zohhak</groupId>
-      <artifactId>zohhak</artifactId>
+      <artifactId>mockito-core</artifactId>
     </dependency>
     <dependency>
       <groupId>uk.co.datumedge</groupId>

--- a/knotx-knot/knotx-knot-service/src/test/java/io/knotx/knot/service/ServiceCorrectConfigurationTest.java
+++ b/knotx-knot/knotx-knot-service/src/test/java/io/knotx/knot/service/ServiceCorrectConfigurationTest.java
@@ -22,20 +22,14 @@ import static org.hamcrest.core.Is.is;
 import io.knotx.junit.util.FileReader;
 import io.vertx.core.json.JsonObject;
 import org.hamcrest.Matchers;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class ServiceCorrectConfigurationTest {
-
-  @Rule
-  public final ExpectedException exception = ExpectedException.none();
-
   private ServiceKnotOptions correctConfig;
   private ServiceMetadata expectedService;
 
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
     JsonObject config = new JsonObject(FileReader.readText("service-correct.json"));
     correctConfig = new ServiceKnotOptions(config);

--- a/knotx-knot/knotx-knot-service/src/test/java/io/knotx/knot/service/impl/FragmentContextTest.java
+++ b/knotx-knot/knotx-knot-service/src/test/java/io/knotx/knot/service/impl/FragmentContextTest.java
@@ -19,20 +19,18 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static uk.co.datumedge.hamcrest.json.SameJSONAs.sameJSONAs;
 
-import com.googlecode.zohhak.api.Configure;
-import com.googlecode.zohhak.api.TestWith;
-import com.googlecode.zohhak.api.runners.ZohhakRunner;
 import io.knotx.dataobjects.Fragment;
-import io.knotx.junit.coercers.KnotxCoercers;
+import io.knotx.junit5.KnotxArgumentConverter;
 import io.knotx.knot.service.service.ServiceEntry;
 import io.vertx.core.json.JsonObject;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.converter.ConvertWith;
+import org.junit.jupiter.params.provider.CsvSource;
 
-@RunWith(ZohhakRunner.class)
-@Configure(separator = ";", coercers = KnotxCoercers.class)
 public class FragmentContextTest {
 
-  @TestWith({
+  @ParameterizedTest
+  @CsvSource(delimiter = ';', value = {
       "snippet_one_service_no_params.txt;{}",
       "snippet_one_service_invalid_params_bound.txt;{}",
       "snippet_one_service_one_param.txt;{\"path\":\"/overridden/path\"}",
@@ -40,14 +38,15 @@ public class FragmentContextTest {
       "snippet_one_service_many_params-no-prefix.txt;{\"path\":\"/overridden/path\",\"anotherParam\":\"someValue\"}",
   })
   public void from_whenFragmentContainsOneService_expectFragmentContextWithExtractedParamsParams(
-      Fragment fragment, String expectedParameters) throws Exception {
+      @ConvertWith(KnotxArgumentConverter.class) Fragment fragment, String expectedParameters) {
 
     final FragmentContext fragmentContext = FragmentContext.from(fragment);
     final ServiceEntry serviceEntry = fragmentContext.services.get(0);
     assertThat(serviceEntry.getParams().toString(), sameJSONAs(expectedParameters));
   }
 
-  @TestWith({
+  @ParameterizedTest
+  @CsvSource(delimiter = ';', value = {
       "snippet_one_service_no_params.txt;1",
       "snippet_one_service_one_param.txt;1",
       "snippet_one_service_many_params.txt;1",
@@ -57,19 +56,20 @@ public class FragmentContextTest {
       "snippet_one_service_many_params-no-prefix.txt;1"
   })
   public void from_whenFragmentContainsServices_expectFragmentContextWithProperNumberOfServicesExtracted(
-      Fragment fragment, int numberOfExpectedServices) throws Exception {
+      @ConvertWith(KnotxArgumentConverter.class) Fragment fragment, int numberOfExpectedServices) {
 
     final FragmentContext fragmentContext = FragmentContext.from(fragment);
     assertThat(fragmentContext.services.size(), is(numberOfExpectedServices));
   }
 
-  @TestWith({
+  @ParameterizedTest
+  @CsvSource(delimiter = ';', value = {
       "snippet_two_services_with_params.txt;{\"first\":{\"first-service-key\":\"first-service-value\"},\"second\":{\"second-service-key\":\"second-service-value\"}}",
       "snippet_four_services_with_params_and_extra_param.txt;{\"a\":{\"a\":\"a\"},\"b\":{\"b\":\"b\"},\"c\":{\"c\":\"c\"},\"d\":{\"d\":\"d\"}}",
       "snippet_four_services_with_params_and_extra_param-no-prefix.txt;{\"a\":{\"a\":\"a\"},\"b\":{\"b\":\"b\"},\"c\":{\"c\":\"c\"},\"d\":{\"d\":\"d\"}}"
   })
   public void from_whenFragmentContainsServices_expectProperlyAssignedParams(
-      Fragment fragment, JsonObject parameters) throws Exception {
+      @ConvertWith(KnotxArgumentConverter.class) Fragment fragment, JsonObject parameters) {
 
     final FragmentContext fragmentContext = FragmentContext.from(fragment);
     fragmentContext.services.forEach(serviceEntry ->

--- a/knotx-knot/knotx-knot-service/src/test/java/io/knotx/knot/service/service/ServiceAttributeUtilTest.java
+++ b/knotx-knot/knotx-knot-service/src/test/java/io/knotx/knot/service/service/ServiceAttributeUtilTest.java
@@ -15,40 +15,41 @@
  */
 package io.knotx.knot.service.service;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import org.apache.commons.lang3.StringUtils;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class ServiceAttributeUtilTest {
 
   @Test
-  public void testAttributeWithoutNamespace() throws Exception {
+  public void testAttributeWithoutNamespace() {
     String serviceNamespace = ServiceAttributeUtil.extractNamespace("data-knotx-service");
     String paramsNamespace = ServiceAttributeUtil.extractNamespace("data-knotx-params");
-    Assert.assertThat(serviceNamespace, is(StringUtils.EMPTY));
-    Assert.assertThat(paramsNamespace, is(StringUtils.EMPTY));
+    assertThat(serviceNamespace, is(StringUtils.EMPTY));
+    assertThat(paramsNamespace, is(StringUtils.EMPTY));
   }
 
   @Test
-  public void testAttributeWithNamespace() throws Exception {
+  public void testAttributeWithNamespace() {
     String serviceNamespace = ServiceAttributeUtil.extractNamespace("data-knotx-service-label");
     String paramsNamespace = ServiceAttributeUtil.extractNamespace("data-knotx-params-label");
-    Assert.assertThat(serviceNamespace, is("label"));
-    Assert.assertThat(paramsNamespace, is("label"));
+    assertThat(serviceNamespace, is("label"));
+    assertThat(paramsNamespace, is("label"));
   }
 
-  @Test(expected = RuntimeException.class)
-  public void testAttributeWithTwoNamespaces() throws Exception {
+  @Test
+  public void testAttributeWithTwoNamespaces() {
     String attributeInput = "data-knotx-service-message-label";
-    ServiceAttributeUtil.extractNamespace(attributeInput);
+    assertThrows(RuntimeException.class, () -> ServiceAttributeUtil.extractNamespace(attributeInput));
   }
 
-  @Test(expected = RuntimeException.class)
-  public void testAttributeWithBrokenNamespace() throws Exception {
+  @Test
+  public void testAttributeWithBrokenNamespace() {
     String attributeInput = "data-knotx-service--label";
-    ServiceAttributeUtil.extractNamespace(attributeInput);
+    assertThrows(RuntimeException.class, () -> ServiceAttributeUtil.extractNamespace(attributeInput));
   }
 
 }

--- a/knotx-knot/knotx-knot-service/src/test/java/io/knotx/knot/service/service/ServiceEntryTest.java
+++ b/knotx-knot/knotx-knot-service/src/test/java/io/knotx/knot/service/service/ServiceEntryTest.java
@@ -16,13 +16,14 @@
 package io.knotx.knot.service.service;
 
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 import io.knotx.junit.util.FileReader;
 import io.knotx.knot.service.ServiceKnotOptions;
 import io.vertx.core.json.JsonObject;
 import org.jsoup.nodes.Attribute;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class ServiceEntryTest {
 
@@ -30,7 +31,7 @@ public class ServiceEntryTest {
 
   private ServiceKnotOptions configNoDefaultParams;
 
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
     configWithDefaultParams = new ServiceKnotOptions(
         new JsonObject(FileReader.readText("service-correct.json"))
@@ -47,7 +48,7 @@ public class ServiceEntryTest {
         new Attribute("data-knotx-service-first", "first-service"),
         new Attribute("data-knotx-params-first", "{\"path\":\"first-service\"}"));
     serviceEntry.mergeParams(configWithDefaultParams.getServices().stream().findFirst().get().getParams());
-    Assert.assertEquals("first-service", serviceEntry.getParams().getString("path"));
+    assertEquals("first-service", serviceEntry.getParams().getString("path"));
   }
 
   @Test
@@ -56,7 +57,7 @@ public class ServiceEntryTest {
         new Attribute("data-knotx-service-first", "first-service"),
         new Attribute("data-knotx-params-first", "{}"));
     serviceEntry.mergeParams(configWithDefaultParams.getServices().stream().findFirst().get().getParams());
-    Assert.assertEquals("/service/mock/first.json", serviceEntry.getParams().getString("path"));
+    assertEquals("/service/mock/first.json", serviceEntry.getParams().getString("path"));
   }
 
   @Test
@@ -65,16 +66,16 @@ public class ServiceEntryTest {
         new Attribute("data-knotx-service-first", "first-service"),
         new Attribute("data-knotx-params-first", "{\"name\":\"first-service-name\"}"));
     serviceEntry.mergeParams(configWithDefaultParams.getServices().stream().findFirst().get().getParams());
-    Assert.assertEquals("/service/mock/first.json", serviceEntry.getParams().getString("path"));
-    Assert.assertEquals("first-service-name", serviceEntry.getParams().getString("name"));
+    assertEquals("/service/mock/first.json", serviceEntry.getParams().getString("path"));
+    assertEquals("first-service-name", serviceEntry.getParams().getString("name"));
   }
 
   @Test
-  public void mergePayload_whenNoDefaultParams_expectDefinedParamsUsed() throws Exception {
+  public void mergePayload_whenNoDefaultParams_expectDefinedParamsUsed() {
     ServiceEntry serviceEntry = new ServiceEntry(
         new Attribute("data-knotx-service-first", "first-service"),
         new Attribute("data-knotx-params-first", "{\"path\":\"some-other-service.json\"}"));
     serviceEntry.mergeParams(configNoDefaultParams.getServices().stream().findFirst().get().getParams());
-    Assert.assertEquals("some-other-service.json", serviceEntry.getParams().getString("path"));
+    assertEquals("some-other-service.json", serviceEntry.getParams().getString("path"));
   }
 }

--- a/knotx-knot/pom.xml
+++ b/knotx-knot/pom.xml
@@ -37,4 +37,39 @@
     <module>knotx-knot-handlebars</module>
   </modules>
 
+  <dependencies>
+    <!-- Test dependencies -->
+    <dependency>
+      <groupId>io.knotx</groupId>
+      <artifactId>knotx-junit5</artifactId>
+      <version>0.0.1-SNAPSHOT</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.vertx</groupId>
+      <artifactId>vertx-junit5</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-params</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-migrationsupport</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.hamcrest</groupId>
+      <artifactId>hamcrest-all</artifactId>
+    </dependency>
+  </dependencies>
+
 </project>

--- a/knotx-knot/pom.xml
+++ b/knotx-knot/pom.xml
@@ -42,7 +42,6 @@
     <dependency>
       <groupId>io.knotx</groupId>
       <artifactId>knotx-junit5</artifactId>
-      <version>0.0.1-SNAPSHOT</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -112,7 +112,7 @@
     <maven.jar.plugin.version>3.0.2</maven.jar.plugin.version>
     <apache.rat.plugin.version>0.12</apache.rat.plugin.version>
     <maven.shade.plugin.version>2.4.3</maven.shade.plugin.version>
-    <maven.surefire.plugin.version>2.19.1</maven.surefire.plugin.version>
+    <maven.surefire.plugin.version>2.21.0</maven.surefire.plugin.version>
     <maven.nexus.staging.plugin.version>1.6.7</maven.nexus.staging.plugin.version>
     <maven.source.plugin.version>2.2.1</maven.source.plugin.version>
     <maven.javadoc.plugin.version>2.9.1</maven.javadoc.plugin.version>
@@ -143,6 +143,20 @@
       <groupId>io.vertx</groupId>
       <artifactId>vertx-codegen</artifactId>
       <scope>provided</scope>
+    </dependency>
+
+    <!-- Required deps for surefire plugin -->
+    <dependency>
+      <groupId>org.junit.platform</groupId>
+      <artifactId>junit-platform-surefire-provider</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.vintage</groupId>
+      <artifactId>junit-vintage-engine</artifactId>
     </dependency>
   </dependencies>
 
@@ -317,6 +331,23 @@
               </vertx.logger-delegate-factory-class-name>
             </systemPropertyVariables>
           </configuration>
+          <dependencies>
+            <dependency>
+              <groupId>org.junit.platform</groupId>
+              <artifactId>junit-platform-surefire-provider</artifactId>
+              <version>1.2.0</version>
+            </dependency>
+            <dependency>
+              <groupId>org.junit.jupiter</groupId>
+              <artifactId>junit-jupiter-engine</artifactId>
+              <version>5.2.0</version>
+            </dependency>
+            <dependency>
+              <groupId>org.junit.vintage</groupId>
+              <artifactId>junit-vintage-engine</artifactId>
+              <version>5.2.0</version>
+            </dependency>
+          </dependencies>
         </plugin>
         <plugin>
           <groupId>org.sonatype.plugins</groupId>


### PR DESCRIPTION
## Description
- Switch from JUnit v4 to v5 for majority of unit, and all integration tests (excluded are `knotx-adapter-*` modules which are already a part of `knotx-data-bridge`; see Knotx/knotx-data-bridge#19)
- Clean up unnecessary Maven test dependencies

Travis build will fail until Knotx/knotx-dependencies#6 and Knotx/knotx-junit5#2 are merged.

*Some fixes may still be necessary*

## Motivation and Context
Part of ongoing work to switch to JUnit 5 in whole Knot.x project. See #417 for further references, scope, and motivation.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

---
I hereby agree to the terms of the Knot.x Contributor License Agreement.
