### PR TITLE
Enable different Vert.x Config stores types fix.

### DIFF
--- a/knotx-core/src/main/java/io/knotx/launcher/KnotxStarterVerticle.java
+++ b/knotx-core/src/main/java/io/knotx/launcher/KnotxStarterVerticle.java
@@ -39,7 +39,7 @@ public class KnotxStarterVerticle extends AbstractVerticle {
   private static final String CONFIG_OVERRIDE = "config";
   private static final String MODULE_OPTIONS = "options";
   private static final Logger LOGGER = LoggerFactory.getLogger(KnotxStarterVerticle.class);
-  public static final String FILE_STORE = "file";
+  private static final String FILE_STORE = "file";
   private List<ModuleDescriptor> deployedModules;
   private ConfigRetriever configRetriever;
 
@@ -56,8 +56,7 @@ public class KnotxStarterVerticle extends AbstractVerticle {
           LOGGER.warn("Configuration changed - Re-deploying Knot.x");
           Observable.fromIterable(deployedModules)
               .flatMap(item -> vertx.rxUndeploy(item.getDeploymentId()).toObservable())
-              .collect(() -> Lists.newArrayList(),
-                  (collector, result) -> collector.add(result))
+              .collect(Lists::newArrayList, ArrayList::add)
               .subscribe(
                   success -> {
                     LOGGER.warn("Knot.x STOPPED.");
@@ -116,8 +115,7 @@ public class KnotxStarterVerticle extends AbstractVerticle {
           throw new BadKnotxConfigurationException("Unable to resolve ${KNOTX_HOME} for " + path
               + ". System property 'knotx.home', or environment variable 'KNOTX_HOME' are not set");
         }
-      }
-      if (home != null) {
+      } else {
         resolvedPath = path.replace("${KNOTX_HOME}", home);
       }
     }

--- a/knotx-core/src/main/java/io/knotx/launcher/KnotxStarterVerticle.java
+++ b/knotx-core/src/main/java/io/knotx/launcher/KnotxStarterVerticle.java
@@ -39,6 +39,7 @@ public class KnotxStarterVerticle extends AbstractVerticle {
   private static final String CONFIG_OVERRIDE = "config";
   private static final String MODULE_OPTIONS = "options";
   private static final Logger LOGGER = LoggerFactory.getLogger(KnotxStarterVerticle.class);
+  public static final String FILE_STORE = "file";
   private List<ModuleDescriptor> deployedModules;
   private ConfigRetriever configRetriever;
 
@@ -90,8 +91,12 @@ public class KnotxStarterVerticle extends AbstractVerticle {
       configOptions = config.getJsonObject("configRetrieverOptions");
       configOptions.getJsonArray("stores").stream()
           .map(item -> (JsonObject) item)
-          .forEach(store -> store.getJsonObject("config")
-              .put("path", resolveConfigPath(store.getJsonObject("config").getString("path"))));
+          .forEach(store -> {
+            if (FILE_STORE.equals(store.getString("type"))) {
+              store.getJsonObject("config")
+                  .put("path", resolveConfigPath(store.getJsonObject("config").getString("path")));
+            }
+          });
 
     } else {
       throw new BadKnotxConfigurationException(


### PR DESCRIPTION
Bugfix for Vert.x Config stores other than the file store.

## Description
We want to be able to define different Vert.x Config store types, not only file store.

## Motivation and Context
It allows to define dynamic ports in configuration for tests.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the [code style](https://github.com/Cognifide/knotx/blob/master/CONTRIBUTING.md#coding-conventions) of this project.
- [X] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

---
I hereby agree to the terms of the Knot.x Contributor License Agreement.
