### PR TITLE
#434 Vert.x version upgrade to 3.5.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to Knot.x will be documented in this file.
 List of changes that are finished but not yet released in any final version.
  - [PR-427[(https://github.com/Cognifide/knotx/pull/427) - HttpRepositoryConnectorProxyImpl logging improvements
  - [PR-422](https://github.com/Cognifide/knotx/pull/422) - Configurable Handlebars delimiters
+ - [PR-428](https://github.com/Cognifide/knotx/pull/428) - Mark all Service Knot related classes deprecated.
+ - [PR-432](https://github.com/Cognifide/knotx/pull/432) - Port unit and integration tests to JUnit 5
+ - [PR-440](https://github.com/Cognifide/knotx/pull/440) - Enable different Vert.x Config stores types fix.
+ - [PR-443](https://github.com/Cognifide/knotx/pull/443) - Update maven plugins versions.
+ - [PR-445](https://github.com/Cognifide/knotx/pull/445) - Vert.x version upgrade to 3.5.3
 
 ## 1.3.0
  - [PR-376](https://github.com/Cognifide/knotx/pull/376) - Knot.x configurations refactor - Changed the way how configurations and it's defaults are build.

--- a/knotx-core/src/test/java/io/knotx/server/KnotxServerCsrfTest.java
+++ b/knotx-core/src/test/java/io/knotx/server/KnotxServerCsrfTest.java
@@ -22,6 +22,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.knotx.junit5.KnotxApplyConfiguration;
 import io.knotx.junit5.KnotxExtension;
+import io.netty.handler.codec.http.HttpHeaderNames;
 import io.netty.handler.codec.http.HttpResponseStatus;
 import io.reactivex.Single;
 import io.vertx.ext.web.handler.CSRFHandler;
@@ -127,6 +128,8 @@ public class KnotxServerCsrfTest {
 
             client.post(KNOTX_SERVER_PORT, KNOTX_SERVER_ADDRESS, "/content/local/simple.html")
                 .putHeader(CSRFHandler.DEFAULT_HEADER_NAME, token)
+                .putHeader(HttpHeaderNames.COOKIE.toString(),
+                    CSRFHandler.DEFAULT_COOKIE_NAME + "=" + token)
                 .sendForm(body, res -> {
                   if (res.succeeded()) {
                     assertEquals(HttpResponseStatus.OK.code(), res.result().statusCode());


### PR DESCRIPTION
Vert.x dependencies upgrade to 3.5.3. Note that this PR contains only a test case fix. All versions are delivered via [Knot.x Dependencies](https://github.com/Knotx/knotx-dependencies).

## Description
CSRF token must be passed in the header and cookie for POST requests.

## Motivation and Context
Vert.x supports the last stable version.


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code style](https://github.com/Cognifide/knotx/blob/master/CONTRIBUTING.md#coding-conventions) of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

---
I hereby agree to the terms of the Knot.x Contributor License Agreement.
