### PR TITLE
fixed typo in logger format (URI already contains leading slash)

### DIFF
--- a/knotx-core/src/main/java/io/knotx/repository/http/HttpRepositoryConnectorProxyImpl.java
+++ b/knotx-core/src/main/java/io/knotx/repository/http/HttpRepositoryConnectorProxyImpl.java
@@ -68,7 +68,7 @@ public class HttpRepositoryConnectorProxyImpl implements RepositoryConnectorProx
 
     RequestOptions httpRequestData = buildRequestData(request);
 
-    if (LOGGER.isDebugEnabled()) {    	
+    if (LOGGER.isDebugEnabled()) {
       LOGGER.debug("GET HTTP Repository: {}  with headers [{}]",
     	  getUrl(httpRequestData),
           DataObjectsUtil.toString(requestHeaders)
@@ -86,9 +86,9 @@ public class HttpRepositoryConnectorProxyImpl implements RepositoryConnectorProx
             }
         );
   }
-  
+
   private String getUrl(RequestOptions httpRequestData) {
-    return String.format("%s://%s:%d/%s ",
+    return String.format("%s://%s:%d%s ",
         httpRequestData.isSsl() ? "https" : "http",
         httpRequestData.getHost(),
         httpRequestData.getPort(),
@@ -152,7 +152,7 @@ public class HttpRepositoryConnectorProxyImpl implements RepositoryConnectorProx
 
   private ClientResponse toResponse(Buffer buffer, final HttpClientResponse httpResponse, final RequestOptions httpRequestData) {
     final int statusCode = httpResponse.statusCode();
-    
+
     if (HttpStatusClass.SUCCESS.contains(statusCode)) {
       LOGGER.debug("Repository 2xx response: {}, Headers[{}]", statusCode,
           DataObjectsUtil.toString(httpResponse.headers()));


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Logger adds an excessive slash to the URL. 
actual: https://server:443//my/uri 
expected: https://server:443/my/uri

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
fixes remove the excessive slash from log file

## Screenshots (if appropriate)

## Upgrade notes (if appropriate)
<!-- What changes user have to do in order to migrate from the previous version to the version with this feature -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code style](/CONTRIBUTING.md#coding-conventions) of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

---
I hereby agree to the terms of the Knot.x Contributor License Agreement.
