### PR TITLE
Switch to knotx template engine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to Knot.x will be documented in this file.
 List of changes that are finished but not yet released in any final version.
  - [PR-465](https://github.com/Cognifide/knotx/pull/465) - Action Knot functionality moved to [Knot.x Forms](https://github.com/Knotx/knotx-forms).
  - [PR-467](https://github.com/Cognifide/knotx/pull/467) - fixed typo in logger format (URI already contains leading slash)
+ - [PR-473](https://github.com/Cognifide/knotx/pull/473) - mark Handlebars Knot as deprecated on behalf of [Knot.x Template Engine](https://github.com/Knotx/knotx-template-engine).
 
 ### Breaking changes
 #### Migration form Action Knot to Knot.x Forms

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,6 +89,45 @@ Knot.x (<= 1.4.0) used earlier Action Knot. Please follow step below in order to
 Refactor your custom adapter to inherit [`io.knotx.proxy.AdapterProxy`](https://github.com/Cognifide/knotx/blob/1.3.0/knotx-core/src/main/java/io/knotx/proxy/AdapterProxy.java)
 to [`io.knotx.forms.api.FormsAdapterProxy`](https://github.com/Knotx/knotx-forms/blob/master/api/src/main/java/io/knotx/forms/api/FormsAdapterProxy.java)
 
+#### Migration form Handlebars Knot to Knot.x Template Engine
+Knot.x (<= 1.5.0) used `HandlebarsKnot`. Please follow step below in order 
+to migrate your project from `HandlebarsKnot` to `Template Engine` module.
+
+Handlebars is still the default Template Engine strategy in Knot.x. Thanks to moving into Template Engine module you may now easily
+create and configure your own Template Engine strategy and choose some snippets to be rendered by it.
+See the [example project](https://github.com/Knotx/knotx-example-project) for more details.
+
+> Notice! You may still use old Handlebars Knot with Knot.x 1.5 if you want.
+> However, remember that it is marked as @Deprecated and will be removed in the next major version.
+
+##### Configuration file:
+1. In your main config `application.conf`, update `modules` section from:
+  ```
+    "hbsKnot=io.knotx.knot.templating.HandlebarsKnotVerticle"
+  ```
+  to 
+  ```
+    "templateEngine=io.knotx.te.core.TemplateEngineKnot"
+  ``` 
+  
+2. Define module address in the `global` section
+  ```
+  global {
+    ...
+    templateEngine.address = knotx.knot.te
+  }
+  ```
+3. Replace all occurenes of the Handlebars Knot address in the Server routing `defaultFlow` from `${global.hbs.address}` to `${global.templateEngine.address}`.
+
+3. Instead including `hbsKnot.conf` change include to `templateEngine.conf`. You will find examples configuration files in 
+the [knotx-stack distribution](https://github.com/Knotx/knotx-stack/blob/master/knotx-stack-manager/src/main/packaging/conf/includes).
+
+##### Page templates:
+
+1. Update `data-knotx-knots` values from `handlebars` to `te`.
+
+2. Example helpers: `string_equals` and `encode_uri` that were embedded into Handlebars Knot are no longer available in the Template Engine.
+You may introduce them by defining handlebars extension as it is presented in the [example project](https://github.com/Knotx/knotx-example-project/tree/master/acme-handlebars-ext).
 
 
 ## 1.4.0

--- a/documentation/src/main/wiki/HandlebarsKnot.md
+++ b/documentation/src/main/wiki/HandlebarsKnot.md
@@ -1,4 +1,8 @@
 # Handlebars Knot
+| ! Note |
+|:------ |
+| @Deprecated: As of release 1.5.0, replaced by [Knot.x Template Engine](https://github.com/Knotx/knotx-template-engine). |
+
 Handlebars Knot is a [[Knot|Knot]] implementation responsible for handlebars template processing.
 
 ## How does it work?

--- a/knotx-knot/knotx-knot-handlebars/src/main/java/io/knotx/knot/templating/HandlebarsKnotOptions.java
+++ b/knotx-knot/knotx-knot-handlebars/src/main/java/io/knotx/knot/templating/HandlebarsKnotOptions.java
@@ -20,7 +20,11 @@ import io.vertx.core.json.JsonObject;
 
 /**
  * Describes Handlebars Knot configuration
+ *
+ * @deprecated  As of release 1.5.0, replaced by <a href="https://github.com/Knotx/knotx-template-engine/">Template Engine</a>
+ * @see <a href="https://github.com/Knotx/knotx-template-engine">Knot.x Template Engine</a>
  */
+@Deprecated
 @DataObject(generateConverter = true, publicConverter = false)
 public class HandlebarsKnotOptions {
 

--- a/knotx-knot/knotx-knot-handlebars/src/main/java/io/knotx/knot/templating/HandlebarsKnotVerticle.java
+++ b/knotx-knot/knotx-knot-handlebars/src/main/java/io/knotx/knot/templating/HandlebarsKnotVerticle.java
@@ -26,6 +26,11 @@ import io.vertx.core.logging.Logger;
 import io.vertx.core.logging.LoggerFactory;
 import io.vertx.serviceproxy.ServiceBinder;
 
+/**
+ * @deprecated  As of release 1.5.0, replaced by <a href="https://github.com/Knotx/knotx-template-engine/blob/master/core/src/main/java/io/knotx/te/core/TemplateEngineKnot.java">Template Engine Knot</a>
+ * @see <a href="https://github.com/Knotx/knotx-template-engine">Knot.x Template Engine</a>
+ */
+@Deprecated
 public class HandlebarsKnotVerticle extends AbstractVerticle {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(HandlebarsKnotVerticle.class);

--- a/knotx-knot/knotx-knot-handlebars/src/main/java/io/knotx/knot/templating/handlebars/CustomHandlebarsHelper.java
+++ b/knotx-knot/knotx-knot-handlebars/src/main/java/io/knotx/knot/templating/handlebars/CustomHandlebarsHelper.java
@@ -35,7 +35,11 @@ import com.github.jknack.handlebars.Helper;
  * </ul>
  *
  * @see Helper
+ *
+ * @deprecated  As of release 1.5.0, replaced by <a href="https://github.com/Knotx/knotx-template-engine/">Template Engine</a>
+ * @see <a href="https://github.com/Knotx/knotx-template-engine">Knot.x Template Engine</a>
  */
+@Deprecated
 public interface CustomHandlebarsHelper<T> extends Helper<T> {
 
   /**

--- a/knotx-knot/knotx-knot-handlebars/src/main/java/io/knotx/knot/templating/handlebars/JsonObjectValueResolver.java
+++ b/knotx-knot/knotx-knot-handlebars/src/main/java/io/knotx/knot/templating/handlebars/JsonObjectValueResolver.java
@@ -23,7 +23,11 @@ import java.util.Set;
 
 /**
  * A {@link JsonObject} value resolver.
+ *
+ * @deprecated  As of release 1.5.0, replaced by <a href="https://github.com/Knotx/knotx-template-engine/">Template Engine</a>
+ * @see <a href="https://github.com/Knotx/knotx-template-engine">Knot.x Template Engine</a>
  */
+@Deprecated
 public enum JsonObjectValueResolver implements ValueResolver {
   /**
    * A singleton instance.

--- a/knotx-knot/knotx-knot-handlebars/src/main/java/io/knotx/knot/templating/helpers/DefaultHandlebarsHelpers.java
+++ b/knotx-knot/knotx-knot-handlebars/src/main/java/io/knotx/knot/templating/helpers/DefaultHandlebarsHelpers.java
@@ -24,6 +24,11 @@ import java.nio.charset.StandardCharsets;
 import java.util.stream.Stream;
 import org.apache.commons.lang3.StringUtils;
 
+/**
+ * @deprecated  As of release 1.5.0, replaced by <a href="https://github.com/Knotx/knotx-template-engine/">Template Engine</a>
+ * @see <a href="https://github.com/Knotx/knotx-template-engine">Knot.x Template Engine</a>
+ */
+@Deprecated
 public enum DefaultHandlebarsHelpers implements Helper<Object> {
 
   /**

--- a/knotx-knot/knotx-knot-handlebars/src/main/java/io/knotx/knot/templating/impl/HandlebarsKnotProxyImpl.java
+++ b/knotx-knot/knotx-knot-handlebars/src/main/java/io/knotx/knot/templating/impl/HandlebarsKnotProxyImpl.java
@@ -46,6 +46,11 @@ import java.util.ServiceLoader;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
 
+/**
+ * @deprecated  As of release 1.5.0, replaced by <a href="https://github.com/Knotx/knotx-template-engine/">Template Engine</a>
+ * @see <a href="https://github.com/Knotx/knotx-template-engine">Knot.x Template Engine</a>
+ */
+@Deprecated
 public class HandlebarsKnotProxyImpl extends AbstractKnotProxy {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(HandlebarsKnotProxyImpl.class);


### PR DESCRIPTION
## Description
Mark Handlebars Knot as deprecated on behalf of [Knot.x Template Engine](https://github.com/Knotx/knotx-template-engine).

## Motivation and Context
HBS Knot is outdated implementation, it will be replaced by dedicated module [Knot.x Template Engine](https://github.com/Knotx/knotx-template-engine) and removed in the future.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code style](/CONTRIBUTING.md#coding-conventions) of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

---
I hereby agree to the terms of the Knot.x Contributor License Agreement.
